### PR TITLE
feat: auto-start server with detection in Chinese chess lobby

### DIFF
--- a/chinese-chess/src/main/java/com/example/chinesechess/ChineseChessMain.java
+++ b/chinese-chess/src/main/java/com/example/chinesechess/ChineseChessMain.java
@@ -1,7 +1,7 @@
 package com.example.chinesechess;
 
 import com.example.chinesechess.ui.GameFrame;
-import com.example.chinesechess.ui.NetworkRoomFrame;
+import com.example.chinesechess.ui.UnifiedNetworkRoomFrame;
 import javax.swing.*;
 import java.awt.*;
 import java.awt.event.ActionEvent;
@@ -189,7 +189,7 @@ public class ChineseChessMain {
      */
     private static void startNetworkGame() {
         System.out.println("🌐 启动网络对弈模式...");
-        NetworkRoomFrame networkFrame = new NetworkRoomFrame();
+        UnifiedNetworkRoomFrame networkFrame = new UnifiedNetworkRoomFrame();
         networkFrame.setVisible(true);
     }
 }

--- a/chinese-chess/src/main/java/com/example/chinesechess/ui/GameFrame.java
+++ b/chinese-chess/src/main/java/com/example/chinesechess/ui/GameFrame.java
@@ -2321,7 +2321,7 @@ public class GameFrame extends JFrame {
             setVisible(false);
             
             // 创建网络房间界面
-            NetworkRoomFrame networkFrame = new NetworkRoomFrame();
+            UnifiedNetworkRoomFrame networkFrame = new UnifiedNetworkRoomFrame();
             networkFrame.setVisible(true);
             
             // 关闭当前游戏界面


### PR DESCRIPTION
## Summary
- rename `NetworkRoomFrame` to `UnifiedNetworkRoomFrame` and add server auto-start with detection
- show alert panel and status label when local server is not running
- update references to new frame in `ChineseChessMain` and `GameFrame`

## Testing
- `cd chinese-chess && mvn -DskipTests package` *(failed: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a13effe9648321a4249fa820498a11