### PR TITLE
feat: add game center with room management

### DIFF
--- a/chinese-chess/src/main/java/com/example/chinesechess/network/ChessGameServer.java
+++ b/chinese-chess/src/main/java/com/example/chinesechess/network/ChessGameServer.java
@@ -138,14 +138,14 @@ public class ChessGameServer {
     /**
      * 创建房间
      */
-    public String createRoom(String hostPlayerId, String roomName, String password) {
+    public String createRoom(String hostPlayerId, String roomName, String password, String gameType) {
         ClientHandler host = clients.get(hostPlayerId);
         if (host == null) {
             return null;
         }
         
         String roomId = "room_" + roomIdCounter.getAndIncrement();
-        GameRoom room = new GameRoom(roomId, roomName, password, hostPlayerId, host.getPlayerName());
+        GameRoom room = new GameRoom(roomId, roomName, password, hostPlayerId, host.getPlayerName(), gameType);
         rooms.put(roomId, room);
         
         System.out.println("🏠 房间创建: " + roomId + " (" + roomName + ") by " + host.getPlayerName());
@@ -211,19 +211,22 @@ public class ChessGameServer {
     /**
      * 获取房间列表
      */
-    public List<RoomInfo> getRoomList() {
+    public List<RoomInfo> getRoomList(String gameType) {
         List<RoomInfo> roomList = new ArrayList<>();
         for (GameRoom room : rooms.values()) {
-            RoomInfo info = new RoomInfo(
-                room.getRoomId(),
-                room.getRoomName(),
-                room.getHostName(),
-                room.getPlayerCount(),
-                2, // 最大玩家数
-                false, // 没有密码
-                room.getGameState()
-            );
-            roomList.add(info);
+            if (gameType == null || gameType.isEmpty() || gameType.equals(room.getGameType())) {
+                RoomInfo info = new RoomInfo(
+                    room.getRoomId(),
+                    room.getRoomName(),
+                    room.getHostName(),
+                    room.getPlayerCount(),
+                    2, // 最大玩家数
+                    false, // 没有密码
+                    room.getGameState(),
+                    room.getGameType()
+                );
+                roomList.add(info);
+            }
         }
         return roomList;
     }
@@ -338,13 +341,15 @@ public class ChessGameServer {
         private String gameState;
         private String redPlayer;
         private String blackPlayer;
+        private final String gameType;
         
-        public GameRoom(String roomId, String roomName, String password, String hostId, String hostName) {
+        public GameRoom(String roomId, String roomName, String password, String hostId, String hostName, String gameType) {
             this.roomId = roomId;
             this.roomName = roomName;
             this.password = password != null ? password : "";
             this.hostId = hostId;
             this.hostName = hostName;
+            this.gameType = gameType;
             this.playerIds = new ArrayList<>();
             this.playerNames = new ArrayList<>();
             this.gameState = "WAITING";
@@ -398,6 +403,7 @@ public class ChessGameServer {
         public String getGameState() { return gameState; }
         public String getRedPlayer() { return redPlayer; }
         public String getBlackPlayer() { return blackPlayer; }
+        public String getGameType() { return gameType; }
         
         public void setGameState(String gameState) { this.gameState = gameState; }
         public void setRedPlayer(String redPlayer) { this.redPlayer = redPlayer; }

--- a/chinese-chess/src/main/java/com/example/chinesechess/network/ClientHandler.java
+++ b/chinese-chess/src/main/java/com/example/chinesechess/network/ClientHandler.java
@@ -135,7 +135,7 @@ public class ClientHandler implements Runnable {
      * 处理创建房间请求
      */
     private void handleCreateRoomRequest(CreateRoomRequestMessage request) {
-        String roomId = server.createRoom(playerId, request.getRoomName(), request.getPassword());
+        String roomId = server.createRoom(playerId, request.getRoomName(), request.getPassword(), request.getGameType());
         
         if (roomId != null) {
             CreateRoomResponseMessage response = new CreateRoomResponseMessage("server", roomId);
@@ -171,7 +171,7 @@ public class ClientHandler implements Runnable {
      * 处理房间列表请求
      */
     private void handleRoomListRequest(RoomListRequestMessage request) {
-        var roomList = server.getRoomList();
+        var roomList = server.getRoomList(request.getGameType());
         RoomListResponseMessage response = new RoomListResponseMessage(roomList);
         sendMessage(response);
         System.out.println("📋 发送房间列表给: " + playerName + " (共" + roomList.size() + "个房间)");

--- a/chinese-chess/src/main/java/com/example/chinesechess/network/CreateRoomRequestMessage.java
+++ b/chinese-chess/src/main/java/com/example/chinesechess/network/CreateRoomRequestMessage.java
@@ -7,12 +7,15 @@ public class CreateRoomRequestMessage extends NetworkMessage {
     private String roomName;
     private String password;
     private int maxPlayers;
-    
-    public CreateRoomRequestMessage(String senderId, String roomName, String password, int maxPlayers) {
+    private String gameType;
+
+    public CreateRoomRequestMessage(String senderId, String roomName, String password,
+                                    int maxPlayers, String gameType) {
         super(MessageType.CREATE_ROOM_REQUEST, senderId);
         this.roomName = roomName;
         this.password = password;
         this.maxPlayers = maxPlayers;
+        this.gameType = gameType;
     }
     
     // Getters and Setters
@@ -24,4 +27,7 @@ public class CreateRoomRequestMessage extends NetworkMessage {
     
     public int getMaxPlayers() { return maxPlayers; }
     public void setMaxPlayers(int maxPlayers) { this.maxPlayers = maxPlayers; }
+
+    public String getGameType() { return gameType; }
+    public void setGameType(String gameType) { this.gameType = gameType; }
 }

--- a/chinese-chess/src/main/java/com/example/chinesechess/network/NetworkClient.java
+++ b/chinese-chess/src/main/java/com/example/chinesechess/network/NetworkClient.java
@@ -465,13 +465,17 @@ public class NetworkClient {
      * 创建房间
      */
     public void createRoom(String roomName, String password) {
+        createRoom(roomName, password, "chinese-chess");
+    }
+
+    public void createRoom(String roomName, String password, String gameType) {
         if (!isConnected || playerId == null) {
             notifyError("未连接到服务器");
             return;
         }
-        
+
         CreateRoomRequestMessage request = new CreateRoomRequestMessage(
-            playerId, roomName, password, 2); // 象棋游戏固定2人
+            playerId, roomName, password, 2, gameType);
         sendMessage(request);
     }
     
@@ -499,6 +503,20 @@ public class NetworkClient {
         
         LeaveRoomMessage message = new LeaveRoomMessage(playerId, null);
         sendMessage(message);
+    }
+
+    public void requestRoomList(String gameType) {
+        if (!isConnected || playerId == null) {
+            notifyError("未连接到服务器");
+            return;
+        }
+
+        RoomListRequestMessage request = new RoomListRequestMessage(playerId, gameType);
+        sendMessage(request);
+    }
+
+    public void requestRoomList() {
+        requestRoomList("chinese-chess");
     }
     
     /**

--- a/chinese-chess/src/main/java/com/example/chinesechess/network/RoomInfo.java
+++ b/chinese-chess/src/main/java/com/example/chinesechess/network/RoomInfo.java
@@ -11,8 +11,10 @@ public class RoomInfo {
     private int maxPlayers;
     private boolean hasPassword;
     private String gameStatus; // "waiting", "playing", "finished"
+    private String gameType;   // 游戏类型
     
-    public RoomInfo(String roomId, String roomName, String hostName, int currentPlayers, int maxPlayers, boolean hasPassword, String gameStatus) {
+    public RoomInfo(String roomId, String roomName, String hostName, int currentPlayers,
+                    int maxPlayers, boolean hasPassword, String gameStatus, String gameType) {
         this.roomId = roomId;
         this.roomName = roomName;
         this.hostName = hostName;
@@ -20,6 +22,7 @@ public class RoomInfo {
         this.maxPlayers = maxPlayers;
         this.hasPassword = hasPassword;
         this.gameStatus = gameStatus;
+        this.gameType = gameType;
     }
     
     // Getters and Setters
@@ -43,4 +46,7 @@ public class RoomInfo {
     
     public String getGameStatus() { return gameStatus; }
     public void setGameStatus(String gameStatus) { this.gameStatus = gameStatus; }
+
+    public String getGameType() { return gameType; }
+    public void setGameType(String gameType) { this.gameType = gameType; }
 }

--- a/chinese-chess/src/main/java/com/example/chinesechess/network/RoomListRequestMessage.java
+++ b/chinese-chess/src/main/java/com/example/chinesechess/network/RoomListRequestMessage.java
@@ -4,7 +4,13 @@ package com.example.chinesechess.network;
  * 房间列表请求消息
  */
 public class RoomListRequestMessage extends NetworkMessage {
-    public RoomListRequestMessage(String senderId) {
+    private String gameType;
+
+    public RoomListRequestMessage(String senderId, String gameType) {
         super(MessageType.ROOM_LIST_REQUEST, senderId);
+        this.gameType = gameType;
     }
+
+    public String getGameType() { return gameType; }
+    public void setGameType(String gameType) { this.gameType = gameType; }
 }

--- a/chinese-chess/src/main/java/com/example/chinesechess/ui/UnifiedNetworkRoomFrame.java
+++ b/chinese-chess/src/main/java/com/example/chinesechess/ui/UnifiedNetworkRoomFrame.java
@@ -2,7 +2,6 @@ package com.example.chinesechess.ui;
 
 import com.example.chinesechess.network.NetworkClient;
 import com.example.chinesechess.network.RoomInfo;
-import com.example.chinesechess.network.RoomListRequestMessage;
 import com.example.chinesechess.network.GameStateSyncRequestMessage;
 import com.example.chinesechess.network.ChessGameServer;
 
@@ -281,8 +280,7 @@ public class UnifiedNetworkRoomFrame extends JFrame implements NetworkClient.Cli
         
         // 请求房间列表
         updateStatus("正在刷新房间列表...");
-        RoomListRequestMessage request = new RoomListRequestMessage(networkClient.getPlayerId());
-        networkClient.sendNetworkMessage(request);
+        networkClient.requestRoomList();
     }
     
     private void showCreateRoomDialog() {

--- a/game-launcher/src/main/java/com/example/launcher/GameCenterFrame.java
+++ b/game-launcher/src/main/java/com/example/launcher/GameCenterFrame.java
@@ -1,0 +1,460 @@
+package com.example.launcher;
+
+import com.example.chinesechess.network.*;
+import com.example.chinesechess.ui.GameFrame;
+
+import javax.swing.*;
+import javax.swing.event.ListSelectionEvent;
+import javax.swing.event.ListSelectionListener;
+import javax.swing.table.DefaultTableModel;
+import java.awt.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.net.BindException;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 游戏中心界面，左侧显示游戏列表，右侧为房间管理
+ */
+public class GameCenterFrame extends JFrame implements NetworkClient.ClientEventListener {
+
+    private static final Map<String, String> GAME_MAP = Map.of(
+            "中国象棋", "chinese-chess",
+            "国际象棋", "international-chess",
+            "五子棋", "gomoku",
+            "围棋", "go-game",
+            "坦克大战", "tank-battle-game",
+            "大富翁", "monopoly"
+    );
+
+    private NetworkClient networkClient;
+    private JTable roomTable;
+    private DefaultTableModel tableModel;
+    private JTextField playerNameField;
+    private JLabel connectionStatusLabel;
+    private JLabel serverStatusLabel;
+    private JButton serverControlButton;
+    private JPanel serverAlertPanel;
+    private ChessGameServer localServer;
+    private Thread serverThread;
+    private String selectedGameType;
+
+    public GameCenterFrame() {
+        setTitle("游戏中心");
+        setSize(1000, 600);
+        setLocationRelativeTo(null);
+        setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+
+        networkClient = new NetworkClient();
+        networkClient.setEventListener(this);
+
+        selectedGameType = GAME_MAP.values().iterator().next();
+
+        initUI();
+        setupEventHandlers();
+        autoStartServerWithDetection();
+    }
+
+    private void initUI() {
+        JSplitPane splitPane = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT);
+        splitPane.setDividerLocation(200);
+
+        // Left game list
+        JList<String> gameList = new JList<>(GAME_MAP.keySet().toArray(new String[0]));
+        gameList.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
+        gameList.setSelectedIndex(0);
+        gameList.addListSelectionListener(new ListSelectionListener() {
+            @Override
+            public void valueChanged(ListSelectionEvent e) {
+                if (!e.getValueIsAdjusting()) {
+                    String selected = gameList.getSelectedValue();
+                    selectedGameType = GAME_MAP.get(selected);
+                    refreshRoomList();
+                }
+            }
+        });
+        splitPane.setLeftComponent(new JScrollPane(gameList));
+
+        // Right room panel
+        JPanel rightPanel = new JPanel(new BorderLayout());
+        JPanel topPanel = createConnectionPanel();
+        serverAlertPanel = createServerAlertPanel();
+        rightPanel.add(topPanel, BorderLayout.NORTH);
+        rightPanel.add(serverAlertPanel, BorderLayout.SOUTH);
+
+        JPanel centerPanel = createRoomListPanel();
+        rightPanel.add(centerPanel, BorderLayout.CENTER);
+
+        JPanel bottomPanel = createButtonPanel();
+        rightPanel.add(bottomPanel, BorderLayout.SOUTH);
+
+        splitPane.setRightComponent(rightPanel);
+        add(splitPane);
+    }
+
+    private JPanel createConnectionPanel() {
+        JPanel panel = new JPanel(new FlowLayout(FlowLayout.LEFT));
+        panel.setBorder(BorderFactory.createTitledBorder("服务器连接"));
+
+        panel.add(new JLabel("玩家名:"));
+        playerNameField = new JTextField("Player" + (int)(Math.random() * 1000), 10);
+        panel.add(playerNameField);
+
+        JButton connectButton = new JButton("连接");
+        connectButton.addActionListener(e -> connectToServer());
+        panel.add(connectButton);
+
+        JButton disconnectButton = new JButton("断开");
+        disconnectButton.addActionListener(e -> disconnectFromServer());
+        panel.add(disconnectButton);
+
+        serverControlButton = new JButton("启动服务器");
+        serverControlButton.addActionListener(e -> toggleServer());
+        panel.add(serverControlButton);
+
+        serverStatusLabel = new JLabel("服务器: 未运行");
+        panel.add(serverStatusLabel);
+
+        connectionStatusLabel = new JLabel("未连接");
+        panel.add(connectionStatusLabel);
+
+        return panel;
+    }
+
+    private JPanel createServerAlertPanel() {
+        JPanel panel = new JPanel(new FlowLayout(FlowLayout.LEFT));
+        panel.setBackground(new Color(255, 228, 181));
+        JLabel label = new JLabel("本地服务器未运行。点击‘启动服务器’一键开启。");
+        JButton startBtn = new JButton("启动服务器");
+        startBtn.addActionListener(e -> toggleServer());
+        panel.add(label);
+        panel.add(startBtn);
+        panel.setVisible(false);
+        return panel;
+    }
+
+    private JPanel createRoomListPanel() {
+        JPanel panel = new JPanel(new BorderLayout());
+        panel.setBorder(BorderFactory.createTitledBorder("房间列表"));
+
+        String[] columnNames = {"房间ID", "房间名", "主机", "玩家数", "状态"};
+        tableModel = new DefaultTableModel(columnNames, 0) {
+            @Override
+            public boolean isCellEditable(int row, int column) {
+                return false;
+            }
+        };
+        roomTable = new JTable(tableModel);
+        roomTable.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
+        roomTable.getTableHeader().setReorderingAllowed(false);
+        JScrollPane scrollPane = new JScrollPane(roomTable);
+        panel.add(scrollPane, BorderLayout.CENTER);
+
+        JButton refreshButton = new JButton("刷新房间列表");
+        refreshButton.addActionListener(e -> refreshRoomList());
+        panel.add(refreshButton, BorderLayout.SOUTH);
+
+        return panel;
+    }
+
+    private JPanel createButtonPanel() {
+        JPanel panel = new JPanel(new FlowLayout());
+
+        JButton createRoomButton = new JButton("创建房间");
+        createRoomButton.addActionListener(e -> showCreateRoomDialog());
+        panel.add(createRoomButton);
+
+        JButton joinRoomButton = new JButton("加入房间");
+        joinRoomButton.addActionListener(e -> joinSelectedRoom());
+        panel.add(joinRoomButton);
+
+        return panel;
+    }
+
+    private void setupEventHandlers() {
+        roomTable.addMouseListener(new java.awt.event.MouseAdapter() {
+            @Override
+            public void mouseClicked(java.awt.event.MouseEvent evt) {
+                if (evt.getClickCount() == 2) {
+                    joinSelectedRoom();
+                }
+            }
+        });
+    }
+
+    private void connectToServer() {
+        if (networkClient.isConnected()) {
+            return;
+        }
+        networkClient.connect("localhost", 8080, playerNameField.getText().trim());
+    }
+
+    private void disconnectFromServer() {
+        if (networkClient.isConnected()) {
+            networkClient.disconnect();
+        }
+    }
+
+    private void refreshRoomList() {
+        if (!networkClient.isConnected()) {
+            return;
+        }
+        connectionStatusLabel.setText("刷新房间列表...");
+        networkClient.requestRoomList(selectedGameType);
+    }
+
+    private void showCreateRoomDialog() {
+        if (!networkClient.isConnected()) {
+            JOptionPane.showMessageDialog(this, "请先连接到服务器", "提示", JOptionPane.WARNING_MESSAGE);
+            return;
+        }
+
+        String roomName = JOptionPane.showInputDialog(this, "请输入房间名:", "创建房间", JOptionPane.PLAIN_MESSAGE);
+        if (roomName != null && !roomName.trim().isEmpty()) {
+            networkClient.createRoom(roomName.trim(), "", selectedGameType);
+        }
+    }
+
+    private void joinSelectedRoom() {
+        if (!networkClient.isConnected()) {
+            JOptionPane.showMessageDialog(this, "请先连接到服务器", "提示", JOptionPane.WARNING_MESSAGE);
+            return;
+        }
+
+        int selectedRow = roomTable.getSelectedRow();
+        if (selectedRow == -1) {
+            JOptionPane.showMessageDialog(this, "请选择一个房间", "提示", JOptionPane.WARNING_MESSAGE);
+            return;
+        }
+
+        String roomId = (String) tableModel.getValueAt(selectedRow, 0);
+        networkClient.joinRoom(roomId, "");
+    }
+
+    private void toggleServer() {
+        if (localServer == null) {
+            autoStartServerWithDetection();
+        } else {
+            stopLocalServer();
+        }
+    }
+
+    private void autoStartServerWithDetection() {
+        try {
+            localServer = new ChessGameServer(8080);
+            serverThread = new Thread(() -> localServer.start());
+            serverThread.start();
+            serverStatusLabel.setText("服务器: 运行中");
+            serverAlertPanel.setVisible(false);
+        } catch (RuntimeException e) {
+            if (e.getCause() instanceof BindException) {
+                serverStatusLabel.setText("服务器: 运行中");
+                serverAlertPanel.setVisible(false);
+            } else {
+                serverStatusLabel.setText("服务器: 启动失败");
+                serverAlertPanel.setVisible(true);
+            }
+            localServer = null;
+        }
+    }
+
+    private void stopLocalServer() {
+        if (localServer != null) {
+            localServer.stop();
+            localServer = null;
+            serverStatusLabel.setText("服务器: 未运行");
+            serverAlertPanel.setVisible(true);
+        }
+    }
+
+    // ============ NetworkClient callbacks ============
+
+    @Override
+    public void onConnected() {
+        connectionStatusLabel.setText("已连接");
+        refreshRoomList();
+    }
+
+    @Override
+    public void onDisconnected(String reason) {
+        connectionStatusLabel.setText("已断开");
+    }
+
+    @Override
+    public void onConnectionError(String error) {
+        connectionStatusLabel.setText("连接错误: " + error);
+    }
+
+    @Override
+    public void onMessageReceived(NetworkMessage message) {}
+
+    @Override
+    public void onRoomCreated(String roomId) {
+        SwingUtilities.invokeLater(() -> {
+            if ("chinese-chess".equals(selectedGameType)) {
+                startNetworkGame(roomId, "");
+            } else {
+                startSelectedGame();
+            }
+        });
+    }
+
+    @Override
+    public void onRoomJoined(String roomId, String opponentName) {
+        SwingUtilities.invokeLater(() -> {
+            if ("chinese-chess".equals(selectedGameType)) {
+                startNetworkGame(roomId, opponentName);
+            } else {
+                startSelectedGame();
+            }
+        });
+    }
+
+    @Override
+    public void onRoomListReceived(List<RoomInfo> rooms) {
+        SwingUtilities.invokeLater(() -> {
+            tableModel.setRowCount(0);
+            for (RoomInfo room : rooms) {
+                Object[] row = {
+                        room.getRoomId(),
+                        room.getRoomName(),
+                        room.getHostName(),
+                        room.getCurrentPlayers() + "/" + room.getMaxPlayers(),
+                        room.getGameStatus()
+                };
+                tableModel.addRow(row);
+            }
+            connectionStatusLabel.setText("房间列表已更新");
+        });
+    }
+
+    @Override
+    public void onGameStarted(String redPlayer, String blackPlayer, String yourColor) {}
+
+    @Override
+    public void onMoveReceived(int fromRow, int fromCol, int toRow, int toCol) {}
+
+    @Override
+    public void onGameEnded(String winner, String reason) {}
+
+    @Override
+    public void onGameStateUpdate(String gameState, String currentPlayer, boolean isGameOver, String winner) {}
+
+    @Override
+    public void onError(String error) {
+        JOptionPane.showMessageDialog(this, error, "错误", JOptionPane.ERROR_MESSAGE);
+    }
+
+    private void startSelectedGame() {
+        dispose();
+        switch (selectedGameType) {
+            case "international-chess":
+                startInternationalChess();
+                break;
+            case "gomoku":
+                startGomoku();
+                break;
+            case "go-game":
+                startGoGame();
+                break;
+            case "tank-battle-game":
+                startTankBattle();
+                break;
+            case "monopoly":
+                startMonopoly();
+                break;
+            case "chinese-chess":
+            default:
+                startChineseChess();
+                break;
+        }
+    }
+
+    private void startChineseChess() {
+        SwingUtilities.invokeLater(() -> {
+            try {
+                Class<?> gameFrameClass = Class.forName("com.example.chinesechess.ChineseChessMain");
+                gameFrameClass.getMethod("main", String[].class).invoke(null, (Object) new String[]{});
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        });
+    }
+
+    private void startInternationalChess() {
+        SwingUtilities.invokeLater(() -> {
+            try {
+                Class<?> gameFrameClass = Class.forName("com.example.internationalchess.InternationalChessFrame");
+                Object frame = gameFrameClass.getDeclaredConstructor().newInstance();
+                gameFrameClass.getMethod("setVisible", boolean.class).invoke(frame, true);
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        });
+    }
+
+    private void startGomoku() {
+        SwingUtilities.invokeLater(() -> {
+            try {
+                Class<?> gameFrameClass = Class.forName("com.example.gomoku.GomokuFrame");
+                Object frame = gameFrameClass.getDeclaredConstructor().newInstance();
+                gameFrameClass.getMethod("setVisible", boolean.class).invoke(frame, true);
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        });
+    }
+
+    private void startGoGame() {
+        SwingUtilities.invokeLater(() -> {
+            try {
+                Class<?> gameClass = Class.forName("com.example.gogame.GoGame");
+                gameClass.getMethod("main", String[].class).invoke(null, (Object) new String[]{});
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        });
+    }
+
+    private void startTankBattle() {
+        SwingUtilities.invokeLater(() -> {
+            try {
+                Class<?> gameClass = Class.forName("com.tankbattle.TankBattleGame");
+                gameClass.getMethod("main", String[].class).invoke(null, (Object) new String[]{});
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        });
+    }
+
+    private void startMonopoly() {
+        SwingUtilities.invokeLater(() -> {
+            try {
+                Class<?> gameFrameClass = Class.forName("com.example.monopoly.MonopolyFrame");
+                Object frame = gameFrameClass.getDeclaredConstructor().newInstance();
+                gameFrameClass.getMethod("setVisible", boolean.class).invoke(frame, true);
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        });
+    }
+
+    private void startNetworkGame(String roomId, String opponentName) {
+        try {
+            GameFrame gameFrame = new GameFrame();
+            gameFrame.setNetworkMode(true);
+            gameFrame.setRoomInfo(roomId, "房间" + roomId);
+            gameFrame.setLocalPlayerName(playerNameField.getText().trim());
+            gameFrame.setNetworkClient(networkClient);
+            GameStateSyncRequestMessage syncReq = new GameStateSyncRequestMessage(
+                    networkClient.getPlayerId(), roomId, "listener_ready");
+            networkClient.sendNetworkMessage(syncReq);
+            gameFrame.setVisible(true);
+            dispose();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+}
+

--- a/game-launcher/src/main/java/com/example/launcher/GameLauncher.java
+++ b/game-launcher/src/main/java/com/example/launcher/GameLauncher.java
@@ -10,7 +10,7 @@ public class GameLauncher {
         SwingUtilities.invokeLater(() -> {
             try {
                 System.out.println("正在启动多游戏平台...");
-                GameSelectionFrame frame = new GameSelectionFrame();
+                GameCenterFrame frame = new GameCenterFrame();
                 frame.setVisible(true);
             } catch (Exception e) {
                 e.printStackTrace();

--- a/start-game.sh
+++ b/start-game.sh
@@ -29,9 +29,9 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
-echo "编译完成，启动游戏选择界面..."
+echo "编译完成，启动游戏中心界面..."
 
-# 启动游戏启动器（使用打包后的JAR文件）
+# 启动游戏中心
 java -cp game-launcher/target/game-launcher-1.0-SNAPSHOT.jar com.example.launcher.GameLauncher
 
 if [ $? -ne 0 ]; then


### PR DESCRIPTION
## Summary
- Introduce `GameCenterFrame` with a selectable list of six games and a room table for network play.
- Track game type across network messages and server so room lists filter by selected game.
- Auto-start and control local server from the game center; update start script messaging.

## Testing
- `mvn -q -pl chinese-chess,game-launcher test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68a14cdb4c788321bdd7e4858d90684b