### PR TITLE
feat: enhance game center ui and connection

### DIFF
--- a/chinese-chess/src/main/java/com/example/chinesechess/network/ConnectionState.java
+++ b/chinese-chess/src/main/java/com/example/chinesechess/network/ConnectionState.java
@@ -1,0 +1,10 @@
+package com.example.chinesechess.network;
+
+/**
+ * Represents network connection state.
+ */
+public enum ConnectionState {
+    DISCONNECTED,
+    CONNECTING,
+    CONNECTED
+}

--- a/game-launcher/src/main/java/com/example/launcher/util/GameContext.java
+++ b/game-launcher/src/main/java/com/example/launcher/util/GameContext.java
@@ -1,0 +1,18 @@
+package com.example.launcher.util;
+
+/**
+ * Global context for runtime options such as single player flag.
+ */
+public final class GameContext {
+    private static volatile boolean singlePlayer = false;
+
+    private GameContext() {}
+
+    public static void setSinglePlayer(boolean sp) {
+        singlePlayer = sp;
+    }
+
+    public static boolean isSinglePlayer() {
+        return singlePlayer;
+    }
+}

--- a/game-launcher/src/main/java/com/example/launcher/util/GameDisplay.java
+++ b/game-launcher/src/main/java/com/example/launcher/util/GameDisplay.java
@@ -1,0 +1,27 @@
+package com.example.launcher.util;
+
+import java.util.Map;
+
+/**
+ * Utility for mapping game type to human readable Chinese name.
+ */
+public final class GameDisplay {
+    private static final Map<String, String> TYPE_TO_NAME = Map.of(
+            "chinese-chess", "中国象棋",
+            "international-chess", "国际象棋",
+            "gomoku", "五子棋",
+            "go-game", "围棋",
+            "tank-battle-game", "坦克大战",
+            "monopoly", "大富翁"
+    );
+
+    private GameDisplay() {
+    }
+
+    /**
+     * Returns Chinese display name for game type code.
+     */
+    public static String name(String gameType) {
+        return TYPE_TO_NAME.getOrDefault(gameType, gameType);
+    }
+}

--- a/game-launcher/src/main/java/com/example/launcher/util/GameIconFactory.java
+++ b/game-launcher/src/main/java/com/example/launcher/util/GameIconFactory.java
@@ -1,0 +1,105 @@
+package com.example.launcher.util;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.geom.RoundRectangle2D;
+import java.awt.image.BufferedImage;
+import java.net.URL;
+
+/**
+ * Factory for game icons. It tries to load an icon from assets/icons/{game}.png.
+ * If the resource is missing, a simple fallback icon will be drawn using Java2D.
+ */
+public final class GameIconFactory {
+    private GameIconFactory() {
+    }
+
+    /**
+     * Creates an icon for the given game type.
+     *
+     * @param gameType type code such as "chinese-chess".
+     * @param size icon size in pixels.
+     * @return icon instance
+     */
+    public static Icon icon(String gameType, int size) {
+        String path = "/assets/icons/" + gameType + ".png";
+        URL url = GameIconFactory.class.getResource(path);
+        if (url != null) {
+            Image img = new ImageIcon(url).getImage().getScaledInstance(size, size, Image.SCALE_SMOOTH);
+            return new ImageIcon(img);
+        }
+        return new FallbackGameIcon(gameType, size);
+    }
+
+    /**
+     * Simple placeholder icon drawn with Java2D for games without assets.
+     */
+    private static class FallbackGameIcon implements Icon {
+        private final String gameType;
+        private final int size;
+
+        FallbackGameIcon(String gameType, int size) {
+            this.gameType = gameType;
+            this.size = size;
+        }
+
+        @Override
+        public void paintIcon(Component c, Graphics g, int x, int y) {
+            Graphics2D g2 = (Graphics2D) g.create();
+            g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+            g2.translate(x, y);
+            switch (gameType) {
+                case "chinese-chess":
+                    g2.setColor(Color.RED);
+                    g2.fillOval(0, 0, size, size);
+                    g2.setColor(Color.WHITE);
+                    g2.drawString("帅", size / 4, (int) (size * 0.7));
+                    break;
+                case "international-chess":
+                    g2.setColor(Color.BLACK);
+                    g2.fill(new RoundRectangle2D.Double(0, size / 4.0, size, size / 2.0, size / 5.0, size / 5.0));
+                    g2.fillOval(size / 4, 0, size / 2, size / 2);
+                    break;
+                case "gomoku":
+                case "go-game":
+                    g2.setColor(Color.LIGHT_GRAY);
+                    for (int i = 0; i < size; i += size / 4) {
+                        g2.drawLine(i, 0, i, size);
+                        g2.drawLine(0, i, size, i);
+                    }
+                    g2.setColor(Color.BLACK);
+                    g2.fillOval(size / 3, size / 3, size / 3, size / 3);
+                    break;
+                case "tank-battle-game":
+                    g2.setColor(Color.GREEN.darker());
+                    g2.fillRect(0, size / 3, size, size / 3);
+                    g2.fillRect(size / 2 - size / 8, size / 6, size / 4, size / 3);
+                    g2.setColor(Color.BLACK);
+                    g2.fillRect(size / 2 - 1, size / 6, size / 2, size / 10);
+                    break;
+                case "monopoly":
+                    g2.setColor(Color.WHITE);
+                    g2.fillRect(0, 0, size, size);
+                    g2.setColor(Color.BLACK);
+                    g2.drawRect(0, 0, size - 1, size - 1);
+                    g2.drawString("5", size / 3, size / 2);
+                    break;
+                default:
+                    g2.setColor(Color.GRAY);
+                    g2.fillRect(0, 0, size, size);
+                    break;
+            }
+            g2.dispose();
+        }
+
+        @Override
+        public int getIconWidth() {
+            return size;
+        }
+
+        @Override
+        public int getIconHeight() {
+            return size;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- show icons with text in game list using a new GameIconFactory fallbacking to Java2D drawings
- display game column and single-player button in room list; added connection state handling
- add connection state enum and safe room leaving in network client

## Testing
- `mvn -q -pl game-launcher,chinese-chess -am -DskipTests compile` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a1cd7b98388321b6f88fcd084380c9