### PR TITLE
feat: refine chinese chess board spacing and animations

### DIFF
--- a/chinese-chess/src/main/java/com/example/chinesechess/ui/GameFrame.java
+++ b/chinese-chess/src/main/java/com/example/chinesechess/ui/GameFrame.java
@@ -146,15 +146,17 @@ public class GameFrame extends JFrame {
         
         
         // 创建主要内容面板（棋盘+右侧面板）
-        JSplitPane splitPane = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT, boardPanel, rightPanel);
-        splitPane.setResizeWeight(0.8);
+        final JSplitPane splitPane = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT, boardPanel, rightPanel);
         splitPane.setContinuousLayout(true);
         splitPane.setOneTouchExpandable(true);
+        splitPane.setDividerLocation(boardPanel.getPreferredSize().width + splitPane.getDividerSize());
         add(splitPane, BorderLayout.CENTER);
 
         addComponentListener(new java.awt.event.ComponentAdapter() {
             @Override
             public void componentResized(java.awt.event.ComponentEvent e) {
+                int divider = boardPanel.getPreferredSize().width + splitPane.getDividerSize();
+                splitPane.setDividerLocation(Math.min(divider, getWidth() - rightPanel.getMinimumSize().width));
                 revalidate();
                 repaint();
             }


### PR DESCRIPTION
## Summary
- adjust Chinese chess layout so board and chat pane resize with the window
- mark pawn/cannon starting points with decorative corner crosses
- animate piece moves with arcing flight, shadow, fade capture and bounce drop
- skip grid lines across the river for a cleaner water effect

## Testing
- `mvn -q -pl chinese-chess -am test` *(fails: PluginResolutionException: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a1d95a52cc8321a7567bf3eaa2fc8d