### PR TITLE
Fix game center navigation and layout issues

### DIFF
--- a/chinese-chess/src/main/java/com/example/chinesechess/ui/GameFrame.java
+++ b/chinese-chess/src/main/java/com/example/chinesechess/ui/GameFrame.java
@@ -105,16 +105,15 @@ public class GameFrame extends JFrame {
 
     public GameFrame() {
         setTitle("🌎 中国象棋 - AI对弈版");
-        setSize(1400, 1000); // 进一步增加窗口尺寸，确保棋盘有足够空间
         setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
-        setLocationRelativeTo(null); // 居中显示
         setLayout(new BorderLayout());
-        setMinimumSize(new Dimension(1200, 900)); // 设置最小尺寸
 
         // 创建棋盘
         Board board = new Board();
         boardPanel = new BoardPanel(board);
         boardPanel.setBorder(BorderFactory.createEmptyBorder(6,6,6,6));
+        Dimension boardSize = new Dimension(800, 800);
+        boardPanel.setPreferredSize(boardSize);
         
         // 创建聊天面板
         chatPanel = new ChatPanel();
@@ -146,8 +145,8 @@ public class GameFrame extends JFrame {
         JPanel rightPanel = new JPanel(new BorderLayout());
         rightPanel.add(rightTabbedPane, BorderLayout.CENTER);
         rightPanel.setBorder(BorderFactory.createEmptyBorder(6,6,6,6));
-        rightPanel.setPreferredSize(new Dimension(FIXED_AI_WIDTH, 400));
-        rightPanel.setMinimumSize(new Dimension(FIXED_AI_WIDTH, 400));
+        rightPanel.setPreferredSize(new Dimension(FIXED_AI_WIDTH, boardSize.height));
+        rightPanel.setMinimumSize(new Dimension(FIXED_AI_WIDTH, boardSize.height));
         rightPanel.setMaximumSize(new Dimension(FIXED_AI_WIDTH, Integer.MAX_VALUE));
         
         
@@ -157,7 +156,7 @@ public class GameFrame extends JFrame {
         splitPane.setResizeWeight(1.0);
         splitPane.setOneTouchExpandable(false);
         splitPane.setDividerSize(6);
-        splitPane.setDividerLocation(getWidth() - FIXED_AI_WIDTH);
+        splitPane.setDividerLocation(boardSize.width);
         splitPane.addPropertyChangeListener(JSplitPane.DIVIDER_LOCATION_PROPERTY, evt -> {
             int fixed = splitPane.getWidth() - FIXED_AI_WIDTH;
             if ((int)evt.getNewValue() != fixed) {
@@ -185,7 +184,7 @@ public class GameFrame extends JFrame {
         statusLabel = new JLabel("🔴 当前玩家: 红方", JLabel.CENTER);
         statusLabel.setFont(new Font("宋体", Font.BOLD, 14));
         statusLabel.setBorder(BorderFactory.createEmptyBorder(3, 10, 3, 10));
-        statusLabel.setPreferredSize(new Dimension(1300, 30)); // 减小状态栏高度，为棋盘留出更多空间
+        statusLabel.setPreferredSize(new Dimension(0, 30));
         add(statusLabel, BorderLayout.SOUTH);
 
         // 设置BoardPanel的状态更新回调
@@ -193,6 +192,8 @@ public class GameFrame extends JFrame {
         
         // 默认启用大模型AI
         initializeDefaultAI();
+        pack();
+        setLocationRelativeTo(null);
     }
     
     /**

--- a/go-game/src/main/java/com/example/go/GoFrame.java
+++ b/go-game/src/main/java/com/example/go/GoFrame.java
@@ -813,16 +813,23 @@ public class GoFrame extends JFrame {
                     chatPanel.setKataGoAI(katagoAI);
                 } else {
                     ExceptionHandler.logInfo("围棋游戏", "⚠️ KataGo引擎初始化失败，使用备用AI");
-                    // 初始化备用AI
+                    // 初始化备用AI并设置到棋盘
                     fallbackAI = new GoAI(1, difficulty); // 1代表WHITE
+                    boardPanel.setGoAI(fallbackAI);
+                    // 备用AI不支持聊天功能
+                    chatPanel.setKataGoAI(null);
+                    chatPanel.setEnabled(false);
                 }
             }));
-            
+
         } catch (Exception e) {
             ExceptionHandler.logError("围棋游戏", "AI初始化失败: " + e.getMessage());
-            // 使用备用AI
+            // 使用备用AI并设置到棋盘
             int difficulty = difficultyCombo.getSelectedIndex() + 1;
             fallbackAI = new GoAI(1, difficulty);
+            boardPanel.setGoAI(fallbackAI);
+            chatPanel.setKataGoAI(null);
+            chatPanel.setEnabled(false);
         }
     }
     

--- a/tank-battle-game/src/main/java/com/tankbattle/TankBattleGame.java
+++ b/tank-battle-game/src/main/java/com/tankbattle/TankBattleGame.java
@@ -4,6 +4,8 @@ import javax.swing.*;
 import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 
 /**
  * 坦克大战游戏主类
@@ -12,8 +14,14 @@ public class TankBattleGame {
     private JFrame mainFrame;
     private GamePanel gamePanel;
     private NetworkManager networkManager;
-    
+    private Runnable onExit;
+
     public TankBattleGame() {
+        this(null);
+    }
+
+    public TankBattleGame(Runnable onExit) {
+        this.onExit = onExit;
         initializeUI();
     }
     
@@ -68,7 +76,17 @@ public class TankBattleGame {
     
     private void initializeUI() {
         mainFrame = new JFrame("坦克大战 - Tank Battle");
-        mainFrame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+        mainFrame.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
+        mainFrame.addWindowListener(new WindowAdapter() {
+            @Override
+            public void windowClosed(WindowEvent e) {
+                if (onExit != null) {
+                    onExit.run();
+                } else {
+                    System.exit(0);
+                }
+            }
+        });
         mainFrame.setSize(1000, 800);
         mainFrame.setResizable(false);
         mainFrame.setLocationRelativeTo(null);
@@ -94,7 +112,7 @@ public class TankBattleGame {
         newGameItem.addActionListener(e -> startSinglePlayerGame());
         hostGameItem.addActionListener(e -> showHostGameDialog());
         joinGameItem.addActionListener(e -> showJoinGameDialog());
-        exitItem.addActionListener(e -> System.exit(0));
+        exitItem.addActionListener(e -> mainFrame.dispose());
         
         gameMenu.add(newGameItem);
         gameMenu.addSeparator();
@@ -143,7 +161,7 @@ public class TankBattleGame {
         singlePlayerBtn.addActionListener(e -> startSinglePlayerGame());
         hostGameBtn.addActionListener(e -> showHostGameDialog());
         joinGameBtn.addActionListener(e -> showJoinGameDialog());
-        exitBtn.addActionListener(e -> System.exit(0));
+        exitBtn.addActionListener(e -> mainFrame.dispose());
         
         gbc.gridy = 1;
         menuPanel.add(singlePlayerBtn, gbc);


### PR DESCRIPTION
## Summary
- Enable Go game single-player mode with fallback AI when KataGo fails
- Ensure Tank Battle returns to game center instead of exiting
- Keep game list order fixed and support Tank Battle window callback
- Let Chinese Chess window size adjust dynamically to layout

## Testing
- `mvn -q -pl game-launcher,tank-battle-game,go-game,chinese-chess -am test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a1f38d11a48321a1ec5ce809ac78d8