### PR TITLE
Add runtime-synthesized wood/stone sound effects

### DIFF
--- a/chinese-chess/src/main/java/com/example/chinesechess/ui/BoardPanel.java
+++ b/chinese-chess/src/main/java/com/example/chinesechess/ui/BoardPanel.java
@@ -34,7 +34,9 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.TimeUnit;
 import javax.swing.Timer;
-import com.example.common.sound.SoundPlayer;
+import audio.SoundManager;
+import static audio.SoundManager.Event.*;
+import static audio.SoundManager.SoundProfile.*;
 import com.example.chinesechess.network.NetworkClient;
 import com.example.chinesechess.network.*;
 import com.example.chinesechess.network.NetworkMessage.MessageType;
@@ -777,10 +779,10 @@ public class BoardPanel extends JPanel {
                          
                          // 检查游戏是否结束
                          if (gameState == GameState.RED_WINS) {
-                             SoundPlayer.getInstance().playSound("game_win");
+                             SoundManager.play(WOOD, WIN);
                              showGameEndDialog("红方获胜！");
                          } else if (gameState == GameState.BLACK_WINS) {
-                             SoundPlayer.getInstance().playSound("game_win");
+                             SoundManager.play(WOOD, WIN);
                              showGameEndDialog("黑方获胜！");
                          } else if (gameState == GameState.DRAW) {
                              showGameEndDialog("和棋！");
@@ -2421,7 +2423,7 @@ public class BoardPanel extends JPanel {
                 addAILog("system", "游戏结束状态: " + gameState);
                 
                 // 播放胜利音效
-                SoundPlayer.getInstance().playSound("game_win");
+                SoundManager.play(WOOD, WIN);
                 
                 // 检查并显示游戏结束画面
                 checkGameEnd();
@@ -2443,7 +2445,7 @@ public class BoardPanel extends JPanel {
             System.out.println("🎊 游戏结束: " + aiColorName + "AI无法走棋，" + winnerColorName + "获胜！");
             
             // 播放胜利音效
-            SoundPlayer.getInstance().playSound("game_win");
+            SoundManager.play(WOOD, WIN);
             
             // 显示游戏结束画面
             SwingUtilities.invokeLater(() -> {
@@ -3814,8 +3816,8 @@ public class BoardPanel extends JPanel {
             // 通知聊天面板更新棋盘状态
             notifyChatPanelBoardUpdate();
             
-            // 播放悔棋音效
-            SoundPlayer.getInstance().playSound("undo_move");
+            // 播放悔棋音效（使用落子音代替）
+            SoundManager.play(WOOD, PIECE_DROP);
             
             addAILog("system", "悔棋操作完成 - 当前轮到" + (currentPlayer == PieceColor.RED ? "红方" : "黑方"));
             
@@ -4921,10 +4923,10 @@ public class BoardPanel extends JPanel {
             
             // 检查游戏是否结束
             if (gameState == GameState.RED_WINS) {
-                SoundPlayer.getInstance().playSound("game_win");
+                SoundManager.play(WOOD, WIN);
                 showGameEndDialog("红方获胜！");
             } else if (gameState == GameState.BLACK_WINS) {
-                SoundPlayer.getInstance().playSound("game_win");
+                SoundManager.play(WOOD, WIN);
                 showGameEndDialog("黑方获胜！");
             } else if (gameState == GameState.DRAW) {
                 showGameEndDialog("和棋！");
@@ -5090,10 +5092,10 @@ public class BoardPanel extends JPanel {
                         
                         // 检查游戏是否结束
                         if (gameState == GameState.RED_WINS) {
-                            SoundPlayer.getInstance().playSound("game_win");
+                            SoundManager.play(WOOD, WIN);
                             showGameEndDialog("红方获胜！");
                         } else if (gameState == GameState.BLACK_WINS) {
-                            SoundPlayer.getInstance().playSound("game_win");
+                            SoundManager.play(WOOD, WIN);
                             showGameEndDialog("黑方获胜！");
                         } else if (gameState == GameState.DRAW) {
                             showGameEndDialog("和棋！");
@@ -5702,7 +5704,7 @@ public class BoardPanel extends JPanel {
                 "现在轮到您了！");
             
             // 可选：播放提示音
-            SoundPlayer.getInstance().playSound("game_start");
+            SoundManager.play(WOOD, PIECE_DROP);
             
         } catch (Exception e) {
             System.err.println("❌ 推断玩家颜色时出错: " + e.getMessage());
@@ -6022,7 +6024,7 @@ public class BoardPanel extends JPanel {
         private void startBounce() {
             overlayLayer.playImpactRing(endX, endY);
             impactAnimator.blastAt(endRow, endCol, 2.5, 4, 160);
-            SoundPlayer.getInstance().playSound("piece_drop");
+            SoundManager.play(WOOD, capturedPiece != null ? PIECE_CAPTURE : PIECE_DROP);
             bounceProgress = 0.0;
             timer = new Timer(16, e -> {
                 bounceProgress += 16.0 / 60.0;

--- a/game-common/src/main/java/audio/PercSynth.java
+++ b/game-common/src/main/java/audio/PercSynth.java
@@ -1,0 +1,104 @@
+package audio;
+
+import javax.sound.sampled.AudioFormat;
+import java.util.Random;
+
+/**
+ * Utility class generating short percussive hits using basic DSP.
+ * The synthesis is intentionally simple but produces distinct
+ * wood or stone like sounds depending on parameters.
+ */
+public final class PercSynth {
+    private static final Random RND = new Random();
+
+    private PercSynth() {}
+
+    public static byte[] pluckHit(AudioFormat fmt, int durationMs, float baseHz,
+                                  float hardness, float body) {
+        int sr = (int) fmt.getSampleRate();
+        int total = durationMs * sr / 1000;
+        double[] buf = new double[total];
+
+        // initial impulse and noise
+        for (int i = 0; i < Math.min(total, sr / 400); i++) {
+            buf[i] += Math.exp(-i * 40.0 / sr);
+        }
+        for (int i = 0; i < total; i++) {
+            buf[i] += (RND.nextDouble() * 2 - 1) * 0.2 * hardness;
+        }
+
+        // resonant peak to emulate material body
+        double q = body * 15 + 5;
+        iirPeak(buf, sr, baseHz, q, 0.9);
+
+        // extra brightness for harder material
+        if (hardness > 0.6f) {
+            hipass(buf, sr, 1200, 0.2);
+        }
+
+        // attack-decay envelope
+        double atk = 0.002;
+        double dec = 0.10 + body * 0.12;
+        applyAD(buf, sr, atk, dec);
+
+        return toPcm16(buf);
+    }
+
+    // ==== DSP helpers ====
+    private static void iirPeak(double[] x, int sr, double f0, double q, double gain) {
+        double w0 = 2 * Math.PI * f0 / sr;
+        double alpha = Math.sin(w0) / (2 * q);
+        double A = Math.sqrt(gain);
+        double b0 = 1 + alpha * A;
+        double b1 = -2 * Math.cos(w0);
+        double b2 = 1 - alpha * A;
+        double a0 = 1 + alpha / A;
+        double a1 = -2 * Math.cos(w0);
+        double a2 = 1 - alpha / A;
+
+        double z1 = 0, z2 = 0;
+        for (int i = 0; i < x.length; i++) {
+            double in = x[i];
+            double out = (b0 / a0) * in + (b1 / a0) * z1 + (b2 / a0) * z2 - (a1 / a0) * z1 - (a2 / a0) * z2;
+            z2 = z1;
+            z1 = out;
+            x[i] = out;
+        }
+    }
+
+    private static void hipass(double[] x, int sr, double fc, double mix) {
+        double c = Math.exp(-2 * Math.PI * fc / sr);
+        double hp = 0, prev = 0;
+        for (int i = 0; i < x.length; i++) {
+            double h = c * (hp + x[i] - prev);
+            prev = x[i];
+            hp = h;
+            x[i] = (1 - mix) * x[i] + mix * h;
+        }
+    }
+
+    private static void applyAD(double[] x, int sr, double atkSec, double decSec) {
+        int atk = Math.max(1, (int) (atkSec * sr));
+        int dec = Math.max(1, (int) (decSec * sr));
+        for (int i = 0; i < x.length; i++) {
+            double env = (i < atk) ? (i / (double) atk) : Math.exp(-(i - atk) / (double) dec);
+            x[i] *= env;
+        }
+    }
+
+    private static byte[] toPcm16(double[] x) {
+        double max = 1e-9;
+        for (double v : x) {
+            max = Math.max(max, Math.abs(v));
+        }
+        double gain = 0.9 / max;
+        byte[] out = new byte[x.length * 2];
+        int j = 0;
+        for (double v : x) {
+            int s = (int) Math.round(Math.max(-1, Math.min(1, v * gain)) * 32767.0);
+            out[j++] = (byte) (s & 0xFF);
+            out[j++] = (byte) ((s >> 8) & 0xFF);
+        }
+        return out;
+    }
+}

--- a/game-common/src/main/java/audio/SoundManager.java
+++ b/game-common/src/main/java/audio/SoundManager.java
@@ -1,0 +1,71 @@
+package audio;
+
+import javax.sound.sampled.*;
+import java.io.ByteArrayInputStream;
+import java.util.EnumMap;
+import java.util.Map;
+
+/**
+ * Runtime sound synthesis and playback utility.
+ * Generates short percussive sounds representing different materials
+ * so the game does not rely on external binary assets.
+ */
+public final class SoundManager {
+
+    /** Material profile for different board games. */
+    public enum SoundProfile { WOOD, STONE }
+
+    /** Events that can trigger sounds. */
+    public enum Event { PIECE_DROP, PIECE_CAPTURE, CHECK, WIN }
+
+    private static final AudioFormat FMT = new AudioFormat(44100, 16, 1, true, false);
+
+    // cache for synthesized PCM for each profile/event pair
+    private static final Map<SoundProfile, Map<Event, byte[]>> CACHE = new EnumMap<>(SoundProfile.class);
+
+    static {
+        for (SoundProfile p : SoundProfile.values()) {
+            CACHE.put(p, new EnumMap<>(Event.class));
+        }
+    }
+
+    private SoundManager() {}
+
+    /**
+     * Play a sound for given profile and event. Waveforms are generated on
+     * demand and cached for reuse to minimise latency.
+     */
+    public static void play(SoundProfile profile, Event event) {
+        byte[] pcm = CACHE.get(profile).get(event);
+        if (pcm == null) {
+            pcm = synth(profile, event);
+            CACHE.get(profile).put(event, pcm);
+        }
+        playPcm(pcm);
+    }
+
+    private static void playPcm(byte[] pcm) {
+        try (AudioInputStream ais = new AudioInputStream(
+                new ByteArrayInputStream(pcm), FMT, pcm.length / FMT.getFrameSize())) {
+            Clip clip = AudioSystem.getClip();
+            clip.open(ais);
+            clip.start();
+        } catch (Exception e) {
+            System.err.println("Audio playback failed: " + e.getMessage());
+        }
+    }
+
+    // === synthesis ===
+    private static byte[] synth(SoundProfile profile, Event event) {
+        int ms = switch (event) {
+            case PIECE_DROP -> 120;
+            case PIECE_CAPTURE -> 170;
+            case CHECK -> 220;
+            case WIN -> 300;
+        };
+        float baseHz = (profile == SoundProfile.WOOD) ? 420f : 1500f;
+        float hardness = (profile == SoundProfile.WOOD) ? 0.35f : 0.75f;
+        float body = (profile == SoundProfile.WOOD) ? 0.55f : 0.25f;
+        return PercSynth.pluckHit(FMT, ms, baseHz, hardness, body);
+    }
+}

--- a/go-game/src/main/java/com/example/go/GoBoardPanel.java
+++ b/go-game/src/main/java/com/example/go/GoBoardPanel.java
@@ -1,6 +1,9 @@
 package com.example.go;
 
 import com.example.common.utils.ExceptionHandler;
+import audio.SoundManager;
+import static audio.SoundManager.Event.*;
+import static audio.SoundManager.SoundProfile.*;
 
 import javax.swing.*;
 import java.awt.*;
@@ -190,9 +193,10 @@ public class GoBoardPanel extends JPanel {
         if (pos != null && game.isValidMove(pos.row, pos.col)) {
             if (game.makeMove(pos.row, pos.col)) {
                 lastMove = pos;
+                playMoveSound();
                 updateGameState();
                 repaint();
-                
+
                 // 如果启用AI且轮到AI，让AI走
                 if (aiEnabled && game.getCurrentPlayer() == aiPlayer && !game.isGameEnded()) {
                     SwingUtilities.invokeLater(this::makeAIMove);
@@ -314,6 +318,7 @@ public class GoBoardPanel extends JPanel {
                     if (aiMove != null) {
                         if (game.makeMove(aiMove.row, aiMove.col)) {
                             lastMove = aiMove;
+                            playMoveSound();
                             // 显示数字坐标
                             int displayRow = GoGame.BOARD_SIZE - aiMove.row;
                             int displayCol = aiMove.col + 1;
@@ -372,6 +377,21 @@ public class GoBoardPanel extends JPanel {
             }
         } else {
             lastMove = null;
+        }
+    }
+
+    /**
+     * 播放最近一步棋的音效，根据是否有提子决定落子或吃子音效。
+     */
+    private void playMoveSound() {
+        List<GoMove> history = game.getMoveHistory();
+        if (!history.isEmpty()) {
+            GoMove last = history.get(history.size() - 1);
+            if (!last.capturedStones.isEmpty()) {
+                SoundManager.play(STONE, PIECE_CAPTURE);
+            } else {
+                SoundManager.play(STONE, PIECE_DROP);
+            }
         }
     }
     
@@ -828,6 +848,7 @@ public class GoBoardPanel extends JPanel {
                     if (aiMove != null) {
                         if (game.makeMove(aiMove.row, aiMove.col)) {
                             lastMove = aiMove;
+                            playMoveSound();
                             // 使用数字坐标显示移动
                             int displayRow = GoGame.BOARD_SIZE - aiMove.row; // 19-1 (从上到下)
                             int displayCol = aiMove.col + 1; // 1-19 (从左到右)

--- a/gomoku/src/main/java/com/example/gomoku/ui/GomokuBoardPanel.java
+++ b/gomoku/src/main/java/com/example/gomoku/ui/GomokuBoardPanel.java
@@ -3,7 +3,9 @@ package com.example.gomoku.ui;
 import com.example.gomoku.core.GameState;
 import com.example.gomoku.core.GomokuBoard;
 import com.example.gomoku.ChatPanel;
-import com.example.common.sound.SoundPlayer;
+import audio.SoundManager;
+import static audio.SoundManager.Event.*;
+import static audio.SoundManager.SoundProfile.*;
 import com.example.gomoku.ai.GomokuZeroAI;
 // AI类已在同一个ui包中，无需导入
 
@@ -88,7 +90,7 @@ public class GomokuBoardPanel extends JPanel {
                 moveHistory.add(new GomokuMoveRecord(row, col, board.isBlackTurn() ? GomokuBoard.WHITE : GomokuBoard.BLACK));
                 
                 // 播放落子音效
-                SoundPlayer.getInstance().playSound("piece_drop");
+                SoundManager.play(STONE, PIECE_DROP);
                 
                 // 更新界面
                 repaint();
@@ -163,7 +165,7 @@ public class GomokuBoardPanel extends JPanel {
             moveHistory.add(new GomokuMoveRecord(row, col, board.isBlackTurn() ? GomokuBoard.WHITE : GomokuBoard.BLACK));
             
             // 播放落子音效
-            SoundPlayer.getInstance().playSound("piece_drop");
+                    SoundManager.play(STONE, PIECE_DROP);
             
             // 更新界面
             repaint();
@@ -180,12 +182,12 @@ public class GomokuBoardPanel extends JPanel {
             switch (board.getGameState()) {
                 case BLACK_WINS:
                     status = "⚫ 黑方获胜！";
-                    SoundPlayer.getInstance().playSound("game_win");
+                    SoundManager.play(STONE, WIN);
                     showVictoryAnimation(status);
                     break;
                 case RED_WINS: // 在五子棋中表示白方获胜
                     status = "⚪ 白方获胜！";
-                    SoundPlayer.getInstance().playSound("game_win");
+                    SoundManager.play(STONE, WIN);
                     showVictoryAnimation(status);
                     break;
                 case DRAW:

--- a/gomoku/src/main/java/com/example/gomoku/ui/GomokuBoardPanelAdapter.java
+++ b/gomoku/src/main/java/com/example/gomoku/ui/GomokuBoardPanelAdapter.java
@@ -4,7 +4,9 @@ import com.example.gomoku.core.GameState;
 import com.example.gomoku.core.GomokuBoard;
 import com.example.gomoku.core.GomokuGameManager;
 import com.example.gomoku.ChatPanel;
-import com.example.common.sound.SoundPlayer;
+import audio.SoundManager;
+import static audio.SoundManager.Event.*;
+import static audio.SoundManager.SoundProfile.*;
 
 import javax.swing.*;
 import java.awt.*;
@@ -67,7 +69,7 @@ public class GomokuBoardPanelAdapter extends JPanel {
             boolean success = gameManager.makePlayerMove(row, col);
             if (success) {
                 // 播放落子音效
-                SoundPlayer.getInstance().playSound("piece_drop");
+                SoundManager.play(STONE, PIECE_DROP);
                 
                 // 更新界面
                 repaint();

--- a/international-chess/src/main/java/com/example/internationalchess/ui/InternationalBoardPanel.java
+++ b/international-chess/src/main/java/com/example/internationalchess/ui/InternationalBoardPanel.java
@@ -6,7 +6,9 @@ import com.example.internationalchess.core.GameState;
 import com.example.internationalchess.ai.InternationalChessAI;
 import com.example.internationalchess.ai.StockfishAIAdapter;
 import com.example.internationalchess.ui.StockfishLogPanel;
-import com.example.common.sound.SoundPlayer;
+import audio.SoundManager;
+import static audio.SoundManager.Event.*;
+import static audio.SoundManager.SoundProfile.*;
 
 import javax.swing.*;
 import java.awt.*;
@@ -591,8 +593,9 @@ public class InternationalBoardPanel extends JPanel {
         } else {
             // 尝试移动
             if (board.isValidMove(selectedRow, selectedCol, row, col)) {
+                String targetPiece = board.getPiece(row, col);
                 if (board.movePiece(selectedRow, selectedCol, row, col)) {
-                    SoundPlayer.getInstance().playSound("piece_drop");
+                    SoundManager.play(WOOD, targetPiece != null ? PIECE_CAPTURE : PIECE_DROP);
                     updateStatus("移动成功");
                     
                     // 检查游戏状态
@@ -603,11 +606,11 @@ public class InternationalBoardPanel extends JPanel {
                         SwingUtilities.invokeLater(this::makeAIMove);
                     }
                 } else {
-                    SoundPlayer.getInstance().playSound("invalid");
+                    SoundManager.play(WOOD, PIECE_DROP);
                     updateStatus("移动失败");
                 }
             } else {
-                SoundPlayer.getInstance().playSound("invalid");
+                SoundManager.play(WOOD, PIECE_DROP);
                 updateStatus("无效移动");
             }
             
@@ -797,7 +800,7 @@ public class InternationalBoardPanel extends JPanel {
         boolean isCapture = targetPiece != null;
         
         if (board.movePiece(fromRow, fromCol, toRow, toCol)) {
-            SoundPlayer.getInstance().playSound("piece_drop");
+            SoundManager.play(WOOD, isCapture ? PIECE_CAPTURE : PIECE_DROP);
             
             // 生成移动描述
             String moveDescription = generateMoveDescription(piece, fromRow, fromCol, toRow, toCol, isCapture, targetPiece);
@@ -926,12 +929,12 @@ public class InternationalBoardPanel extends JPanel {
             case WHITE_WIN:
             case WHITE_CHECKMATE:
                 updateStatus("🎉 白方获胜！");
-                SoundPlayer.getInstance().playSound("game_win");
+                SoundManager.play(WOOD, WIN);
                 break;
             case BLACK_WIN:
             case BLACK_CHECKMATE:
                 updateStatus("🎉 黑方获胜！");
-                SoundPlayer.getInstance().playSound("game_win");
+                SoundManager.play(WOOD, WIN);
                 break;
             case DRAW:
             case STALEMATE:


### PR DESCRIPTION
## Summary
- generate short percussive sounds at runtime with new `SoundManager` and `PercSynth`
- trigger wood sounds for Chinese & international chess, and stone sounds for Go & Gomoku
- play capture and win events with synthesized audio

## Testing
- `mvn -q -pl game-common,chinese-chess,gomoku,international-chess,go-game -am test` *(fails: PluginResolutionException: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1, Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a1f66f66708321b21cdfcbdceecf98