### PR TITLE
Clip specular highlight to piece face

### DIFF
--- a/chinese-chess/src/main/java/com/example/chinesechess/ui/render/PieceRenderer.java
+++ b/chinese-chess/src/main/java/com/example/chinesechess/ui/render/PieceRenderer.java
@@ -194,8 +194,13 @@ public final class PieceRenderer {
                             new Color(255, 255, 255, 0)});
         Shape face = new Ellipse2D.Float(cx - rInner, cy - rInner, rInner * 2f, rInner * 2f);
         Paint old = g.getPaint();
+        Shape clipBak = g.getClip();
+
+        g.setClip(face);
         g.setPaint(gloss);
         g.fill(face);
+
+        g.setClip(clipBak);
         g.setPaint(old);
     }
 


### PR DESCRIPTION
## Summary
- Restrict specular highlight rendering to the inner face area by clipping before fill

## Testing
- `mvn -q -pl chinese-chess test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a205f73dbc8321820573da8fbf584f