### PR TITLE
Ensure Java 11 compatibility and enlarge Chinese chess pieces

### DIFF
--- a/chinese-chess/src/main/java/com/example/chinesechess/ui/BoardPanel.java
+++ b/chinese-chess/src/main/java/com/example/chinesechess/ui/BoardPanel.java
@@ -2570,7 +2570,7 @@ public class BoardPanel extends JPanel {
 
         int centerX = MARGIN + col * CELL_SIZE + impactAnimator.getOffsetX(boardRow, boardCol);
         int centerY = MARGIN + row * CELL_SIZE + impactAnimator.getOffsetY(boardRow, boardCol);
-        int diameter = (int) (CELL_SIZE * 0.75);
+        int diameter = (int) (CELL_SIZE * 0.9);
 
         PieceRenderer.PieceType type = mapPieceType(piece);
         PieceRenderer.Side side = piece.getColor() == PieceColor.RED ? PieceRenderer.Side.RED : PieceRenderer.Side.BLACK;
@@ -5942,7 +5942,7 @@ public class BoardPanel extends JPanel {
         if (alpha < 1f) {
             g2d.setComposite(AlphaComposite.getInstance(AlphaComposite.SRC_OVER, alpha));
         }
-        int size = (int)(CELL_SIZE * 0.75 * scale);
+        int size = (int)(CELL_SIZE * 0.9 * scale);
         PieceRenderer.PieceType type = mapPieceType(piece);
         PieceRenderer.Side side = piece.getColor() == PieceColor.RED ? PieceRenderer.Side.RED : PieceRenderer.Side.BLACK;
         BufferedImage img = PieceRenderer.render(type, side, size, 1f);

--- a/chinese-chess/src/main/java/com/example/chinesechess/ui/render/PieceRenderer.java
+++ b/chinese-chess/src/main/java/com/example/chinesechess/ui/render/PieceRenderer.java
@@ -285,7 +285,7 @@ public final class PieceRenderer {
     }
 
     private static BufferedImage toBuffered(Image img) {
-        if (img instanceof BufferedImage bi) return bi;
+        if (img instanceof BufferedImage) return (BufferedImage) img;
         BufferedImage out = new BufferedImage(img.getWidth(null), img.getHeight(null), BufferedImage.TYPE_INT_ARGB);
         Graphics2D g = out.createGraphics();
         enableAA(g);
@@ -295,17 +295,28 @@ public final class PieceRenderer {
     }
 
     private static String toGlyph(PieceType t, Side s) {
-        return switch (t) {
-            case CHE -> "車";
-            case MA -> "馬";
-            case PAO -> "炮";
-            case SHUAI -> "帥";
-            case JIANG -> "將";
-            case SHI -> (s == Side.RED ? "仕" : "士");
-            case XIANG -> (s == Side.RED ? "相" : "象");
-            case BING -> "兵";
-            case ZU -> "卒";
-        };
+        switch (t) {
+            case CHE:
+                return "車";
+            case MA:
+                return "馬";
+            case PAO:
+                return "炮";
+            case SHUAI:
+                return "帥";
+            case JIANG:
+                return "將";
+            case SHI:
+                return s == Side.RED ? "仕" : "士";
+            case XIANG:
+                return s == Side.RED ? "相" : "象";
+            case BING:
+                return "兵";
+            case ZU:
+                return "卒";
+            default:
+                throw new IllegalArgumentException("Unknown piece type: " + t);
+        }
     }
 
     private static BufferedImage placeholder(PieceType type, Side side, int d) {

--- a/game-common/src/main/java/audio/SoundManager.java
+++ b/game-common/src/main/java/audio/SoundManager.java
@@ -57,12 +57,23 @@ public final class SoundManager {
 
     // === synthesis ===
     private static byte[] synth(SoundProfile profile, Event event) {
-        int ms = switch (event) {
-            case PIECE_DROP -> 120;
-            case PIECE_CAPTURE -> 170;
-            case CHECK -> 220;
-            case WIN -> 300;
-        };
+        int ms;
+        switch (event) {
+            case PIECE_DROP:
+                ms = 120;
+                break;
+            case PIECE_CAPTURE:
+                ms = 170;
+                break;
+            case CHECK:
+                ms = 220;
+                break;
+            case WIN:
+                ms = 300;
+                break;
+            default:
+                throw new IllegalStateException("Unexpected value: " + event);
+        }
         float baseHz = (profile == SoundProfile.WOOD) ? 420f : 1500f;
         float hardness = (profile == SoundProfile.WOOD) ? 0.35f : 0.75f;
         float body = (profile == SoundProfile.WOOD) ? 0.55f : 0.25f;


### PR DESCRIPTION
## Summary
- Replace newer switch expressions in `SoundManager` and `PieceRenderer` with classic Java 11 switch statements
- Remove pattern matching for `instanceof` in piece rendering
- Enlarge Chinese chess pieces by rendering them at 90% of cell size for improved visibility

## Testing
- `mvn -q -pl game-common,chinese-chess test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a2074556fc8321b1ec943c46db5911