### PR TITLE
refine chinese chess piece rendering details

### DIFF
--- a/chinese-chess/src/main/java/com/example/chinesechess/ui/render/PieceRenderer.java
+++ b/chinese-chess/src/main/java/com/example/chinesechess/ui/render/PieceRenderer.java
@@ -90,7 +90,7 @@ public final class PieceRenderer {
         int margin = Math.max(2, Math.round(d * 0.04f));
         int cx = d / 2, cy = d / 2;
         int rOuter = d / 2 - margin;
-        int rimW   = Math.max(3, Math.round(d * 0.08f));
+        int rimW   = Math.max(3, Math.round(d * 0.10f));
         int rInner = rOuter - rimW;
 
         BufferedImage img = new BufferedImage(d, d, BufferedImage.TYPE_INT_ARGB);
@@ -177,7 +177,7 @@ public final class PieceRenderer {
         RadialGradientPaint vignette = new RadialGradientPaint(
                 new Point2D.Float(cx, cy), rInner,
                 new float[]{0f, 1f},
-                new Color[]{new Color(0, 0, 0, 0), new Color(0, 0, 0, 40)});
+                new Color[]{new Color(0, 0, 0, 0), new Color(0, 0, 0, 45)});
         g.setPaint(vignette);
         g.fill(face);
 
@@ -206,7 +206,7 @@ public final class PieceRenderer {
 
     private static void paintGlyph(Graphics2D g, String text, Side side, int cx, int cy, int rInner) {
         Color main = (side == Side.RED) ? RED_GLYPH : BLACK_GLYPH;
-        int fontSize = Math.max(24, Math.round(rInner * 1.2f));
+        int fontSize = Math.max(24, Math.round(rInner * 1.15f));
         Font font = g.getFont().deriveFont(Font.BOLD, fontSize);
         g.setFont(font);
         FontMetrics fm = g.getFontMetrics();


### PR DESCRIPTION
## Summary
- adjust rim thickness to 10% of diameter for a more accurate beveled edge
- slightly darken face vignette and tune glyph size for better balance

## Testing
- `mvn -q -pl chinese-chess -am test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68a20d0b56808321baf5a069a93dcb20