### PR TITLE
Add life-and-death module for Go

### DIFF
--- a/go-game/src/main/java/com/example/go/GoGame.java
+++ b/go-game/src/main/java/com/example/go/GoGame.java
@@ -271,7 +271,29 @@ public class GoGame {
         }
         return sb.toString();
     }
-    
+
+    /**
+     * 载入一个预设的棋盘位置，用于死活题等特殊模式
+     *
+     * @param newBoard      预设棋盘数组
+     * @param startingPlayer 先手棋色
+     */
+    public void loadPosition(int[][] newBoard, int startingPlayer) {
+        initializeBoard();
+        for (int i = 0; i < BOARD_SIZE; i++) {
+            System.arraycopy(newBoard[i], 0, board[i], 0, BOARD_SIZE);
+        }
+        this.currentPlayer = startingPlayer;
+        moveHistory.clear();
+        capturedGroups.clear();
+        blackCaptured = 0;
+        whiteCaptured = 0;
+        gameEnded = false;
+        consecutivePasses = 0;
+        lastBoardState = null;
+        lastCapturePosition = null;
+    }
+
     // Getters
     public int[][] getBoard() {
         return board;

--- a/go-game/src/main/java/com/example/go/GoLifeAndDeathGame.java
+++ b/go-game/src/main/java/com/example/go/GoLifeAndDeathGame.java
@@ -1,0 +1,52 @@
+package com.example.go;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 死活棋模块：提供预设死活题并使用KataGo进行对弈
+ */
+public class GoLifeAndDeathGame extends GoGame {
+    private final List<GoLifeAndDeathProblem> problems = new ArrayList<>();
+    private final KataGoAI ai;
+
+    public GoLifeAndDeathGame() {
+        super();
+        ai = new KataGoAI(3);
+        loadDefaultProblems();
+    }
+
+    private void loadDefaultProblems() {
+        int[][] problem1 = new int[BOARD_SIZE][BOARD_SIZE];
+        // 一个简单的角部死活棋题示例
+        problem1[0][0] = BLACK;
+        problem1[1][0] = WHITE;
+        problem1[0][1] = WHITE;
+        problems.add(new GoLifeAndDeathProblem(problem1, BLACK));
+    }
+
+    /**
+     * 开始指定的死活题
+     */
+    public void startProblem(int index) {
+        if (index < 0 || index >= problems.size()) {
+            throw new IllegalArgumentException("Invalid problem index");
+        }
+        GoLifeAndDeathProblem problem = problems.get(index);
+        loadPosition(problem.getBoard(), problem.getStartingPlayer());
+    }
+
+    /**
+     * 让AI落子
+     */
+    public GoPosition aiMove() {
+        if (!ai.initializeEngine()) {
+            return null;
+        }
+        return ai.calculateBestMove(getBoard(), getCurrentPlayer());
+    }
+
+    public int getProblemCount() {
+        return problems.size();
+    }
+}

--- a/go-game/src/main/java/com/example/go/GoLifeAndDeathProblem.java
+++ b/go-game/src/main/java/com/example/go/GoLifeAndDeathProblem.java
@@ -1,0 +1,22 @@
+package com.example.go;
+
+/**
+ * 表示一个死活棋题，包括初始棋盘和先手方
+ */
+public class GoLifeAndDeathProblem {
+    private final int[][] board;
+    private final int startingPlayer;
+
+    public GoLifeAndDeathProblem(int[][] board, int startingPlayer) {
+        this.board = board;
+        this.startingPlayer = startingPlayer;
+    }
+
+    public int[][] getBoard() {
+        return board;
+    }
+
+    public int getStartingPlayer() {
+        return startingPlayer;
+    }
+}

--- a/go-game/src/test/java/com/example/go/GoLifeAndDeathGameTest.java
+++ b/go-game/src/test/java/com/example/go/GoLifeAndDeathGameTest.java
@@ -1,0 +1,20 @@
+package com.example.go;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+/**
+ * 测试死活棋模块基础功能
+ */
+public class GoLifeAndDeathGameTest {
+    @Test
+    public void testStartProblemLoadsBoardAndPlayer() {
+        GoLifeAndDeathGame game = new GoLifeAndDeathGame();
+        assertTrue(game.getProblemCount() > 0);
+        game.startProblem(0);
+        int[][] board = game.getBoard();
+        assertEquals(GoGame.BLACK, board[0][0]);
+        assertEquals(GoGame.WHITE, board[1][0]);
+        assertEquals(GoGame.BLACK, game.getCurrentPlayer());
+    }
+}


### PR DESCRIPTION
## Summary
- allow GoGame to load preset board positions for specialized modes
- add GoLifeAndDeathGame and GoLifeAndDeathProblem to provide simple life-and-death puzzles with KataGo AI
- cover life-and-death problem loading with a new unit test

## Testing
- `mvn -q -pl go-game -am test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 could not be resolved)*
- `mvn -q -pl go-game -am -o test` *(fails: Cannot access central in offline mode for maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68a20fa89f248321a4ef0ccf0f30aa35