### PR TITLE
Add life-and-death training skeleton

### DIFF
--- a/game-launcher/src/main/java/com/example/launcher/GameCenterFrame.java
+++ b/game-launcher/src/main/java/com/example/launcher/GameCenterFrame.java
@@ -6,6 +6,7 @@ import com.example.chinesechess.ui.GameFrame;
 import com.example.common.game.GameContext;
 import com.example.launcher.util.GameDisplay;
 import com.example.launcher.util.GameIconFactory;
+import com.example.go.lad.LifeAndDeathFrame;
 
 import javax.swing.*;
 import javax.swing.event.ListSelectionEvent;
@@ -31,6 +32,7 @@ public class GameCenterFrame extends JFrame implements NetworkClient.ClientEvent
         map.put("国际象棋", "international-chess");
         map.put("五子棋", "gomoku");
         map.put("围棋", "go-game");
+        map.put("围棋死活", "go-life-and-death");
         map.put("坦克大战", "tank-battle-game");
         map.put("大富翁", "monopoly");
         GAME_MAP = Collections.unmodifiableMap(map);
@@ -97,6 +99,10 @@ public class GameCenterFrame extends JFrame implements NetworkClient.ClientEvent
             public void valueChanged(ListSelectionEvent e) {
                 if (!e.getValueIsAdjusting()) {
                     String selected = gameList.getSelectedValue();
+                    if ("围棋死活".equals(selected)) {
+                        SwingUtilities.invokeLater(() -> new LifeAndDeathFrame().setVisible(true));
+                        return;
+                    }
                     selectedGameType = GAME_MAP.get(selected);
                     refreshRoomList();
                 }

--- a/go-game/src/main/java/com/example/go/lad/FileProgressStore.java
+++ b/go-game/src/main/java/com/example/go/lad/FileProgressStore.java
@@ -1,0 +1,71 @@
+package com.example.go.lad;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.reflect.TypeToken;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.io.Writer;
+import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Stores progress under ~/.yourapp/go/ld_progress.json.
+ */
+public class FileProgressStore implements ProgressStore {
+    private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
+    private final Map<String, ProblemProgress> map = new HashMap<>();
+    private final Path file;
+
+    public FileProgressStore() {
+        file = Path.of(System.getProperty("user.home"), ".yourapp", "go", "ld_progress.json");
+        load();
+    }
+
+    @Override
+    public ProblemProgress get(String id) {
+        return map.computeIfAbsent(id, ProblemProgress::new);
+    }
+
+    @Override
+    public void markPassed(String id, int moves, long timeMs, int usedHints) {
+        ProblemProgress p = get(id);
+        p.passed = true;
+        p.bestMoves = moves;
+        p.bestTimeMs = timeMs;
+        p.usedHints = usedHints;
+        save();
+    }
+
+    private void load() {
+        try {
+            if (Files.exists(file)) {
+                try (Reader r = Files.newBufferedReader(file, StandardCharsets.UTF_8)) {
+                    Type type = new TypeToken<Map<String, ProblemProgress>>(){}.getType();
+                    Map<String, ProblemProgress> data = GSON.fromJson(r, type);
+                    if (data != null) {
+                        map.putAll(data);
+                    }
+                }
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private void save() {
+        try {
+            Files.createDirectories(file.getParent());
+            try (Writer w = Files.newBufferedWriter(file, StandardCharsets.UTF_8)) {
+                GSON.toJson(map, w);
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/go-game/src/main/java/com/example/go/lad/GoBoardPanel.java
+++ b/go-game/src/main/java/com/example/go/lad/GoBoardPanel.java
@@ -1,0 +1,101 @@
+package com.example.go.lad;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.util.function.Consumer;
+
+/**
+ * Minimal board panel capable of drawing a position and notifying on clicks.
+ */
+public class GoBoardPanel extends JPanel {
+    private GoGame game = new GoGame(9);
+    private Consumer<GoPoint> moveListener;
+    private GoPoint lastMove;
+
+    public GoBoardPanel() {
+        setBackground(new Color(0xD69A45));
+        addMouseListener(new MouseAdapter() {
+            @Override
+            public void mouseClicked(MouseEvent e) {
+                GoPoint pt = screenToPoint(e.getX(), e.getY());
+                if (pt != null && moveListener != null) {
+                    moveListener.accept(pt);
+                    lastMove = pt;
+                }
+            }
+        });
+    }
+
+    public void setMoveListener(Consumer<GoPoint> l) { this.moveListener = l; }
+    public GoGame getGame() { return game; }
+
+    public void showPosition(GoLifeAndDeathProblem p) {
+        game = new GoGame(p.size);
+        game.resetTo(p);
+        repaint();
+    }
+
+    public void place(GoPoint pt) {
+        game.play(pt);
+        repaint();
+    }
+
+    private GoPoint screenToPoint(int x, int y) {
+        int size = game.getSize();
+        int margin = 20;
+        int cell = (Math.min(getWidth(), getHeight()) - 2 * margin) / (size - 1);
+        int bx = Math.round((x - margin) / (float) cell) + 1;
+        int by = Math.round((y - margin) / (float) cell) + 1;
+        if (bx >= 1 && bx <= size && by >= 1 && by <= size) {
+            int sx = margin + (bx - 1) * cell;
+            int sy = margin + (by - 1) * cell;
+            if (Math.abs(x - sx) <= cell / 2 && Math.abs(y - sy) <= cell / 2) {
+                return new GoPoint(bx, by);
+            }
+        }
+        return null;
+    }
+
+    @Override
+    protected void paintComponent(Graphics g) {
+        super.paintComponent(g);
+        int size = game.getSize();
+        int margin = 20;
+        int cell = (Math.min(getWidth(), getHeight()) - 2 * margin) / (size - 1);
+        int boardSize = cell * (size - 1);
+        int originX = margin;
+        int originY = margin;
+
+        g.setColor(Color.BLACK);
+        for (int i = 0; i < size; i++) {
+            int x = originX + i * cell;
+            int y = originY + i * cell;
+            g.drawLine(originX, y, originX + boardSize, y);
+            g.drawLine(x, originY, x, originY + boardSize);
+        }
+
+        // draw stones
+        for (int x = 1; x <= size; x++) {
+            for (int y = 1; y <= size; y++) {
+                GoColor c = game.get(x, y);
+                if (c != null) {
+                    int sx = originX + (x - 1) * cell;
+                    int sy = originY + (y - 1) * cell;
+                    g.setColor(c == GoColor.BLACK ? Color.BLACK : Color.WHITE);
+                    g.fillOval(sx - cell / 2, sy - cell / 2, cell, cell);
+                    g.setColor(Color.BLACK);
+                    g.drawOval(sx - cell / 2, sy - cell / 2, cell, cell);
+                }
+            }
+        }
+
+        if (lastMove != null) {
+            int sx = originX + (lastMove.x - 1) * cell;
+            int sy = originY + (lastMove.y - 1) * cell;
+            g.setColor(Color.RED);
+            g.drawRect(sx - cell / 2, sy - cell / 2, cell, cell);
+        }
+    }
+}

--- a/go-game/src/main/java/com/example/go/lad/GoColor.java
+++ b/go-game/src/main/java/com/example/go/lad/GoColor.java
@@ -1,0 +1,9 @@
+package com.example.go.lad;
+
+/**
+ * Simple enumeration for stone colors.
+ */
+public enum GoColor {
+    BLACK,
+    WHITE
+}

--- a/go-game/src/main/java/com/example/go/lad/GoGame.java
+++ b/go-game/src/main/java/com/example/go/lad/GoGame.java
@@ -1,0 +1,54 @@
+package com.example.go.lad;
+
+/**
+ * Minimal Go game state for life-and-death training.
+ */
+public class GoGame {
+    private GoColor[][] board;
+    private GoColor toPlay = GoColor.BLACK;
+    private int moves = 0;
+
+    public GoGame(int size) {
+        board = new GoColor[size + 1][size + 1]; // 1-based index
+    }
+
+    public void resetTo(GoLifeAndDeathProblem p) {
+        board = new GoColor[p.size + 1][p.size + 1];
+        for (GoStone s : p.initial) {
+            if (s.x >= 1 && s.x < board.length && s.y >= 1 && s.y < board.length) {
+                board[s.x][s.y] = s.c;
+            }
+        }
+        toPlay = p.toPlay;
+        moves = 0;
+    }
+
+    public void play(GoPoint pt) {
+        if (pt.x >= 1 && pt.x < board.length && pt.y >= 1 && pt.y < board.length) {
+            if (board[pt.x][pt.y] == null) {
+                board[pt.x][pt.y] = toPlay;
+                toPlay = (toPlay == GoColor.BLACK) ? GoColor.WHITE : GoColor.BLACK;
+                moves++;
+            }
+        }
+    }
+
+    public GoColor get(int x, int y) {
+        if (x >= 1 && x < board.length && y >= 1 && y < board.length) {
+            return board[x][y];
+        }
+        return null;
+    }
+
+    public int getSize() {
+        return board.length - 1;
+    }
+
+    public GoColor getToPlay() {
+        return toPlay;
+    }
+
+    public int getMoveCount() {
+        return moves;
+    }
+}

--- a/go-game/src/main/java/com/example/go/lad/GoLifeAndDeathProblem.java
+++ b/go-game/src/main/java/com/example/go/lad/GoLifeAndDeathProblem.java
@@ -1,0 +1,17 @@
+package com.example.go.lad;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Data model for a life-and-death problem.
+ */
+public class GoLifeAndDeathProblem {
+    public String id;
+    public int size;
+    public GoColor toPlay;
+    public String goal;
+    public List<GoStone> initial = new ArrayList<>();
+    public List<String> hints = List.of();
+    public List<GoPoint> answer = List.of();
+}

--- a/go-game/src/main/java/com/example/go/lad/GoPoint.java
+++ b/go-game/src/main/java/com/example/go/lad/GoPoint.java
@@ -1,0 +1,19 @@
+package com.example.go.lad;
+
+/**
+ * Simple coordinate on the Go board.
+ */
+public class GoPoint {
+    public final int x;
+    public final int y;
+
+    public GoPoint(int x, int y) {
+        this.x = x;
+        this.y = y;
+    }
+
+    @Override
+    public String toString() {
+        return "(" + x + "," + y + ")";
+    }
+}

--- a/go-game/src/main/java/com/example/go/lad/GoStone.java
+++ b/go-game/src/main/java/com/example/go/lad/GoStone.java
@@ -1,0 +1,16 @@
+package com.example.go.lad;
+
+/**
+ * Represents a stone placed on the board.
+ */
+public class GoStone {
+    public final int x;
+    public final int y;
+    public final GoColor c;
+
+    public GoStone(int x, int y, GoColor c) {
+        this.x = x;
+        this.y = y;
+        this.c = c;
+    }
+}

--- a/go-game/src/main/java/com/example/go/lad/JsonProblemRepository.java
+++ b/go-game/src/main/java/com/example/go/lad/JsonProblemRepository.java
@@ -1,0 +1,102 @@
+package com.example.go.lad;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+/**
+ * Loads problems from resources/problems/*.json.
+ */
+public class JsonProblemRepository implements ProblemRepository {
+    private final Map<String, GoLifeAndDeathProblem> cache = new LinkedHashMap<>();
+
+    public JsonProblemRepository() {
+        load();
+    }
+
+    private void load() {
+        try {
+            URL dirURL = getClass().getResource("/problems");
+            if (dirURL == null) {
+                return;
+            }
+            Path dir = Paths.get(dirURL.toURI());
+            try (Stream<Path> paths = Files.list(dir)) {
+                paths.filter(p -> p.toString().endsWith(".json"))
+                        .forEach(this::loadFile);
+            }
+        } catch (URISyntaxException | IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private void loadFile(Path p) {
+        try (Reader reader = Files.newBufferedReader(p, StandardCharsets.UTF_8)) {
+            JsonObject obj = JsonParser.parseReader(reader).getAsJsonObject();
+            GoLifeAndDeathProblem prob = new GoLifeAndDeathProblem();
+            prob.id = obj.get("id").getAsString();
+            prob.size = obj.get("size").getAsInt();
+            prob.toPlay = "W".equalsIgnoreCase(obj.get("toPlay").getAsString()) ? GoColor.WHITE : GoColor.BLACK;
+            prob.goal = obj.get("goal").getAsString();
+
+            JsonArray init = obj.getAsJsonArray("initialStones");
+            if (init != null) {
+                for (JsonElement el : init) {
+                    JsonObject s = el.getAsJsonObject();
+                    int x = s.get("x").getAsInt();
+                    int y = s.get("y").getAsInt();
+                    GoColor c = "W".equalsIgnoreCase(s.get("c").getAsString()) ? GoColor.WHITE : GoColor.BLACK;
+                    prob.initial.add(new GoStone(x, y, c));
+                }
+            }
+
+            if (obj.has("hints")) {
+                List<String> hs = new ArrayList<>();
+                JsonArray arr = obj.getAsJsonArray("hints");
+                for (JsonElement el : arr) hs.add(el.getAsString());
+                prob.hints = hs;
+            }
+
+            if (obj.has("answer")) {
+                List<GoPoint> ans = new ArrayList<>();
+                JsonArray arr = obj.getAsJsonArray("answer");
+                for (JsonElement el : arr) {
+                    String s = el.getAsString();
+                    int x = s.charAt(0) - 'A' + 1;
+                    int y = Integer.parseInt(s.substring(1));
+                    ans.add(new GoPoint(x, y));
+                }
+                prob.answer = ans;
+            }
+
+            cache.put(prob.id, prob);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Override
+    public List<GoLifeAndDeathProblem> list(ProblemFilter f) {
+        return new ArrayList<>(cache.values());
+    }
+
+    @Override
+    public GoLifeAndDeathProblem get(String id) {
+        return cache.get(id);
+    }
+}

--- a/go-game/src/main/java/com/example/go/lad/JudgeResult.java
+++ b/go-game/src/main/java/com/example/go/lad/JudgeResult.java
@@ -1,0 +1,7 @@
+package com.example.go.lad;
+
+public class JudgeResult {
+    public JudgeStatus status;
+    public String reason;
+    public int movesUsed;
+}

--- a/go-game/src/main/java/com/example/go/lad/JudgeStatus.java
+++ b/go-game/src/main/java/com/example/go/lad/JudgeStatus.java
@@ -1,0 +1,5 @@
+package com.example.go.lad;
+
+public enum JudgeStatus {
+    PASS, FAIL, UNKNOWN
+}

--- a/go-game/src/main/java/com/example/go/lad/LifeAndDeathFrame.java
+++ b/go-game/src/main/java/com/example/go/lad/LifeAndDeathFrame.java
@@ -1,0 +1,184 @@
+package com.example.go.lad;
+
+import javax.swing.*;
+import java.awt.*;
+import java.util.List;
+
+/**
+ * Main window for life-and-death training mode.
+ */
+public class LifeAndDeathFrame extends JFrame {
+
+    private JTable problemTable;
+    private ProblemTableModel problemTableModel;
+    private GoBoardPanel boardPanel;
+    private JLabel lblProblemId, lblGoal, lblToPlay, lblStatus;
+    private JTextArea hintArea;
+    private JButton btnUnlockHint, btnSubmit, btnNext, btnReset, btnBack;
+
+    private transient ProblemRepository problemRepo = new JsonProblemRepository();
+    private transient ProgressStore progressStore = new FileProgressStore();
+    private transient LifeAndDeathService ladService = new RuleBasedLifeAndDeathService();
+
+    private GoLifeAndDeathProblem current;
+    private long startTimeMs;
+
+    public LifeAndDeathFrame() {
+        setTitle("围棋 · 死活训练");
+        setSize(1100, 720);
+        setLocationRelativeTo(null);
+
+        buildUI();
+        loadProblems();
+    }
+
+    private void buildUI() {
+        problemTableModel = new ProblemTableModel();
+        problemTable = new JTable(problemTableModel);
+        problemTable.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
+        problemTable.getSelectionModel().addListSelectionListener(e -> {
+            if (!e.getValueIsAdjusting()) {
+                int row = problemTable.getSelectedRow();
+                if (row >= 0) onSelectProblem(problemTableModel.getIdAt(row));
+            }
+        });
+
+        boardPanel = new GoBoardPanel();
+        boardPanel.setMoveListener(pt -> {
+            if (current != null) {
+                boardPanel.place(pt);
+                lblStatus.setText("已落子：" + pt);
+            }
+        });
+
+        JPanel right = buildSidebar();
+
+        JSplitPane leftMiddle = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT,
+                new JScrollPane(problemTable), boardPanel);
+        leftMiddle.setResizeWeight(0.28);
+
+        JSplitPane root = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT, leftMiddle, right);
+        root.setResizeWeight(0.8);
+
+        getContentPane().add(root, BorderLayout.CENTER);
+    }
+
+    private JPanel buildSidebar() {
+        lblProblemId = new JLabel("-");
+        lblGoal = new JLabel("-");
+        lblToPlay = new JLabel("-");
+        lblStatus = new JLabel("请选择关卡…");
+
+        hintArea = new JTextArea(6, 18);
+        hintArea.setEditable(false);
+        hintArea.setLineWrap(true);
+        hintArea.setWrapStyleWord(true);
+
+        btnUnlockHint = new JButton("解锁提示");
+        btnUnlockHint.addActionListener(e -> onUnlockHint());
+
+        btnSubmit = new JButton("提交");
+        btnSubmit.addActionListener(e -> onSubmit());
+
+        btnNext = new JButton("下一题");
+        btnNext.setEnabled(false);
+        btnNext.addActionListener(e -> onNextProblem());
+
+        btnReset = new JButton("重来");
+        btnReset.addActionListener(e -> onReset());
+
+        btnBack = new JButton("返回大厅");
+        btnBack.addActionListener(e -> dispose());
+
+        JPanel info = new JPanel(new GridLayout(0,1,4,4));
+        info.add(new JLabel("题号：")); info.add(lblProblemId);
+        info.add(new JLabel("目标：")); info.add(lblGoal);
+        info.add(new JLabel("手番：")); info.add(lblToPlay);
+
+        JPanel btns = new JPanel(new GridLayout(0,1,6,6));
+        btns.add(btnUnlockHint);
+        btns.add(btnSubmit);
+        btns.add(btnNext);
+        btns.add(btnReset);
+        btns.add(btnBack);
+
+        JPanel p = new JPanel(new BorderLayout(8,8));
+        p.setBorder(BorderFactory.createEmptyBorder(10,10,10,10));
+        p.add(info, BorderLayout.NORTH);
+        p.add(new JScrollPane(hintArea), BorderLayout.CENTER);
+        p.add(btns, BorderLayout.SOUTH);
+        p.add(lblStatus, BorderLayout.PAGE_END);
+        return p;
+    }
+
+    private void loadProblems() {
+        List<GoLifeAndDeathProblem> list = problemRepo.list(new ProblemFilter());
+        problemTableModel.setData(list, progressStore);
+        if (!list.isEmpty()) {
+            problemTable.setRowSelectionInterval(0,0);
+            onSelectProblem(list.get(0).id);
+        }
+    }
+
+    private void onSelectProblem(String id) {
+        this.current = problemRepo.get(id);
+        ladService.load(current, boardPanel.getGame());
+        boardPanel.showPosition(current);
+        startTimeMs = System.currentTimeMillis();
+
+        lblProblemId.setText(current.id);
+        lblGoal.setText(current.goal);
+        lblToPlay.setText(current.toPlay.name());
+        hintArea.setText("");
+        btnNext.setEnabled(false);
+        lblStatus.setText("已载入：" + current.id);
+    }
+
+    private void onUnlockHint() {
+        String next = ladService.nextHint(current, hintArea.getText());
+        if (next == null) {
+            JOptionPane.showMessageDialog(this, "没有更多提示了。");
+        } else {
+            hintArea.append((hintArea.getText().isEmpty()?"":"\n") + "• " + next);
+        }
+    }
+
+    private void onSubmit() {
+        JudgeResult jr = ladService.judge(boardPanel.getGame(), current);
+        if (jr.status == JudgeStatus.PASS) {
+            btnNext.setEnabled(true);
+            long t = System.currentTimeMillis() - startTimeMs;
+            progressStore.markPassed(current.id, jr.movesUsed, t, countHints());
+            lblStatus.setText("正解 ✅ " + jr.reason);
+            JOptionPane.showMessageDialog(this, "正解 ✅\n" + jr.reason, "通过", JOptionPane.INFORMATION_MESSAGE);
+        } else if (jr.status == JudgeStatus.FAIL) {
+            lblStatus.setText("未解 ❌ " + jr.reason);
+            JOptionPane.showMessageDialog(this, "未解 ❌\n" + jr.reason, "再试一次", JOptionPane.WARNING_MESSAGE);
+        } else {
+            lblStatus.setText("暂不确定，继续尝试或解锁提示。");
+        }
+    }
+
+    private int countHints() {
+        String s = hintArea.getText();
+        return (int) s.lines().filter(l -> l.trim().startsWith("•")).count();
+    }
+
+    private void onNextProblem() {
+        String nextId = problemTableModel.getNextId(current.id);
+        if (nextId != null) {
+            onSelectProblem(nextId);
+        } else {
+            JOptionPane.showMessageDialog(this, "已是最后一题。");
+        }
+    }
+
+    private void onReset() {
+        if (current != null) {
+            ladService.load(current, boardPanel.getGame());
+            boardPanel.showPosition(current);
+            startTimeMs = System.currentTimeMillis();
+            lblStatus.setText("已重置。");
+        }
+    }
+}

--- a/go-game/src/main/java/com/example/go/lad/LifeAndDeathService.java
+++ b/go-game/src/main/java/com/example/go/lad/LifeAndDeathService.java
@@ -1,0 +1,7 @@
+package com.example.go.lad;
+
+public interface LifeAndDeathService {
+    void load(GoLifeAndDeathProblem p, GoGame game);
+    JudgeResult judge(GoGame game, GoLifeAndDeathProblem p);
+    String nextHint(GoLifeAndDeathProblem p, String currentHintsText);
+}

--- a/go-game/src/main/java/com/example/go/lad/ProblemFilter.java
+++ b/go-game/src/main/java/com/example/go/lad/ProblemFilter.java
@@ -1,0 +1,5 @@
+package com.example.go.lad;
+
+/** Placeholder for future filtering options. */
+public class ProblemFilter {
+}

--- a/go-game/src/main/java/com/example/go/lad/ProblemProgress.java
+++ b/go-game/src/main/java/com/example/go/lad/ProblemProgress.java
@@ -1,0 +1,14 @@
+package com.example.go.lad;
+
+/** Progress information for a solved problem. */
+public class ProblemProgress {
+    public String id;
+    public boolean passed;
+    public int bestMoves;
+    public long bestTimeMs;
+    public int usedHints;
+
+    public ProblemProgress(String id) {
+        this.id = id;
+    }
+}

--- a/go-game/src/main/java/com/example/go/lad/ProblemRepository.java
+++ b/go-game/src/main/java/com/example/go/lad/ProblemRepository.java
@@ -1,0 +1,8 @@
+package com.example.go.lad;
+
+import java.util.List;
+
+public interface ProblemRepository {
+    List<GoLifeAndDeathProblem> list(ProblemFilter f);
+    GoLifeAndDeathProblem get(String id);
+}

--- a/go-game/src/main/java/com/example/go/lad/ProblemTableModel.java
+++ b/go-game/src/main/java/com/example/go/lad/ProblemTableModel.java
@@ -1,0 +1,56 @@
+package com.example.go.lad;
+
+import javax.swing.table.AbstractTableModel;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Table model displaying problems and progress.
+ */
+public class ProblemTableModel extends AbstractTableModel {
+    private final String[] cols = {"题号","路数","目标","完成","最佳步数","最佳用时"};
+    private final List<GoLifeAndDeathProblem> data = new ArrayList<>();
+    private final Map<String, ProblemProgress> progress = new HashMap<>();
+
+    public void setData(List<GoLifeAndDeathProblem> list, ProgressStore store) {
+        data.clear();
+        data.addAll(list);
+        progress.clear();
+        for (GoLifeAndDeathProblem p : list) {
+            progress.put(p.id, store.get(p.id));
+        }
+        fireTableDataChanged();
+    }
+
+    public String getIdAt(int row) { return data.get(row).id; }
+
+    public String getNextId(String id) {
+        for (int i=0; i<data.size(); i++) {
+            if (data.get(i).id.equals(id)) {
+                return (i+1 < data.size()) ? data.get(i+1).id : null;
+            }
+        }
+        return null;
+    }
+
+    @Override public int getRowCount() { return data.size(); }
+    @Override public int getColumnCount() { return cols.length; }
+    @Override public String getColumnName(int c) { return cols[c]; }
+
+    @Override
+    public Object getValueAt(int r, int c) {
+        GoLifeAndDeathProblem p = data.get(r);
+        ProblemProgress pr = progress.getOrDefault(p.id, new ProblemProgress(p.id));
+        switch (c) {
+            case 0: return p.id;
+            case 1: return p.size;
+            case 2: return p.goal;
+            case 3: return pr.passed ? "✅" : "";
+            case 4: return pr.bestMoves > 0 ? pr.bestMoves : "";
+            case 5: return pr.bestTimeMs > 0 ? (pr.bestTimeMs/1000 + "s") : "";
+            default: return "";
+        }
+    }
+}

--- a/go-game/src/main/java/com/example/go/lad/ProgressStore.java
+++ b/go-game/src/main/java/com/example/go/lad/ProgressStore.java
@@ -1,0 +1,6 @@
+package com.example.go.lad;
+
+public interface ProgressStore {
+    ProblemProgress get(String id);
+    void markPassed(String id, int moves, long timeMs, int usedHints);
+}

--- a/go-game/src/main/java/com/example/go/lad/RuleBasedLifeAndDeathService.java
+++ b/go-game/src/main/java/com/example/go/lad/RuleBasedLifeAndDeathService.java
@@ -1,0 +1,30 @@
+package com.example.go.lad;
+
+import java.util.List;
+
+/**
+ * Placeholder implementation of basic life-and-death judging.
+ */
+public class RuleBasedLifeAndDeathService implements LifeAndDeathService {
+    @Override
+    public void load(GoLifeAndDeathProblem p, GoGame game) {
+        game.resetTo(p);
+    }
+
+    @Override
+    public JudgeResult judge(GoGame game, GoLifeAndDeathProblem p) {
+        JudgeResult r = new JudgeResult();
+        r.status = JudgeStatus.UNKNOWN;
+        r.reason = "基础判定未实现";
+        r.movesUsed = game.getMoveCount();
+        return r;
+    }
+
+    @Override
+    public String nextHint(GoLifeAndDeathProblem p, String currentHintsText) {
+        List<String> hs = p.hints == null ? List.of() : p.hints;
+        long have = currentHintsText == null ? 0 :
+                currentHintsText.lines().filter(l -> l.trim().startsWith("•")).count();
+        return have < hs.size() ? hs.get((int) have) : null;
+    }
+}


### PR DESCRIPTION
## Summary
- add life-and-death training frame with board, hint sidebar, and progress tracking stubs
- load go problems from bundled JSON via new repository and progress store
- hook life-and-death mode into GameCenter with new menu entry

## Testing
- `mvn -q -pl game-launcher -am test` *(fails: PluginResolutionException: maven-resources-plugin:3.3.1, Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a264faced8832190c7ba267ca9e0f7