### PR TITLE
Enhance Go stone drop animation

### DIFF
--- a/go-game/src/main/java/com/example/go/GoBoardPanel.java
+++ b/go-game/src/main/java/com/example/go/GoBoardPanel.java
@@ -201,7 +201,6 @@ public class GoBoardPanel extends JPanel {
         if (pos != null && game.isValidMove(pos.row, pos.col)) {
             if (game.makeMove(pos.row, pos.col)) {
                 lastMove = pos;
-                playMoveSound();
                 startDropAnimation(pos.row, pos.col, game.getBoard()[pos.row][pos.col]);
                 updateGameState();
 
@@ -322,11 +321,10 @@ public class GoBoardPanel extends JPanel {
                 try {
                     GoPosition aiMove = get();
                     thinking = false;
-                    
+
                     if (aiMove != null) {
                         if (game.makeMove(aiMove.row, aiMove.col)) {
                             lastMove = aiMove;
-                            playMoveSound();
                             startDropAnimation(aiMove.row, aiMove.col, game.getBoard()[aiMove.row][aiMove.col]);
                             // 显示数字坐标
                             int displayRow = GoGame.BOARD_SIZE - aiMove.row;
@@ -411,16 +409,18 @@ public class GoBoardPanel extends JPanel {
         animatingMove = new GoPosition(row, col);
         animPlayer = player;
         animEndY = MARGIN + row * CELL_SIZE;
-        animStartY = animEndY - CELL_SIZE * 3;
+        // 从屏幕外顶部开始下落
+        animStartY = -CELL_SIZE * 2;
         animProgress = 0;
         if (dropTimer != null && dropTimer.isRunning()) {
             dropTimer.stop();
         }
         dropTimer = new Timer(15, e -> {
-            animProgress += 0.1;
+            animProgress += 0.05;
             if (animProgress >= 1) {
                 animProgress = 1;
                 dropTimer.stop();
+                playMoveSound();
                 animatingMove = null;
             }
             repaint();
@@ -581,41 +581,38 @@ public class GoBoardPanel extends JPanel {
         // 绘制动画棋子
         if (animatingMove != null && dropTimer != null && dropTimer.isRunning()) {
             int x = MARGIN + animatingMove.col * CELL_SIZE;
-            int y = (int) (animStartY + (animEndY - animStartY) * (1 - Math.pow(1 - animProgress, 3)));
-            drawStone(g2d, x, y, animPlayer);
+            double p = animProgress;
+            double yProgress = easeOutBounce(p);
+            int y = (int) (animStartY + (animEndY - animStartY) * yProgress);
+            double scale = 0.6 + 0.4 * (1 - Math.pow(1 - p, 3));
+            drawStone(g2d, x, y, animPlayer, scale);
         }
     }
 
     private void drawStone(Graphics2D g2d, int x, int y, int player) {
-        // 阴影
-        g2d.setColor(new Color(0, 0, 0, 50));
-        g2d.fillOval(x - STONE_RADIUS + 2, y - STONE_RADIUS + 2,
-                STONE_RADIUS * 2, STONE_RADIUS * 2);
-
-        // 渐变主体
-        if (player == GoGame.BLACK) {
-            RadialGradientPaint gradient = new RadialGradientPaint(
-                    x - 3, y - 3, STONE_RADIUS,
-                    new float[]{0.0f, 1.0f},
-                    new Color[]{new Color(80, 80, 80), Color.BLACK});
-            g2d.setPaint(gradient);
-        } else {
-            RadialGradientPaint gradient = new RadialGradientPaint(
-                    x - 3, y - 3, STONE_RADIUS,
-                    new float[]{0.0f, 1.0f},
-                    new Color[]{Color.WHITE, new Color(200, 200, 200)});
-            g2d.setPaint(gradient);
-        }
-        g2d.fillOval(x - STONE_RADIUS, y - STONE_RADIUS,
-                STONE_RADIUS * 2, STONE_RADIUS * 2);
-
-        // 边框
-        g2d.setColor(Color.BLACK);
-        g2d.setStroke(new BasicStroke(1.0f));
-        g2d.drawOval(x - STONE_RADIUS, y - STONE_RADIUS,
-                STONE_RADIUS * 2, STONE_RADIUS * 2);
+        drawStone(g2d, x, y, player, 1.0);
     }
-    
+
+    private void drawStone(Graphics2D g2d, int x, int y, int player, double scale) {
+        int diameter = Math.max(2, Math.round((float) (STONE_RADIUS * 2 * scale)));
+        GoStoneRenderer.draw(g2d, x, y, diameter, player == GoGame.WHITE);
+    }
+
+    private double easeOutBounce(double t) {
+        if (t < (1 / 2.75)) {
+            return 7.5625 * t * t;
+        } else if (t < (2 / 2.75)) {
+            t -= (1.5 / 2.75);
+            return 7.5625 * t * t + 0.75;
+        } else if (t < (2.5 / 2.75)) {
+            t -= (2.25 / 2.75);
+            return 7.5625 * t * t + 0.9375;
+        } else {
+            t -= (2.625 / 2.75);
+            return 7.5625 * t * t + 0.984375;
+        }
+    }
+
     /**
      * 绘制坐标
      */
@@ -887,11 +884,10 @@ public class GoBoardPanel extends JPanel {
                 try {
                     GoPosition aiMove = get();
                     thinking = false;
-                    
+
                     if (aiMove != null) {
                         if (game.makeMove(aiMove.row, aiMove.col)) {
                             lastMove = aiMove;
-                            playMoveSound();
                             startDropAnimation(aiMove.row, aiMove.col, game.getBoard()[aiMove.row][aiMove.col]);
                             // 使用数字坐标显示移动
                             int displayRow = GoGame.BOARD_SIZE - aiMove.row; // 19-1 (从上到下)


### PR DESCRIPTION
## Summary
- Animate Go stones falling from off-screen with easing, bounce, and scaling
- Use `GoStoneRenderer` for detailed stone rendering and trigger landing sound at end of animation

## Testing
- `mvn -q -pl go-game -am test` *(failed: PluginResolutionException - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a29e8db0e883218260349c6c8f6da1