### PR TITLE
Improve Chinese chess piece animations

### DIFF
--- a/chinese-chess/src/main/java/com/example/chinesechess/ui/BoardPanel.java
+++ b/chinese-chess/src/main/java/com/example/chinesechess/ui/BoardPanel.java
@@ -5932,7 +5932,7 @@ public class BoardPanel extends JPanel {
         int endCol = getDisplayCol(end.getY());
         int centerX = MARGIN + endCol * CELL_SIZE;
         int centerY = MARGIN + endRow * CELL_SIZE;
-        dropAnimation = new PieceDropAnimation(piece, centerX, centerY, 600);
+        dropAnimation = new PieceDropAnimation(piece, centerX, centerY, 400);
         dropAnimation.start();
     }
 
@@ -5992,7 +5992,7 @@ public class BoardPanel extends JPanel {
 
         void start() {
             startTime = System.currentTimeMillis();
-            timer = new Timer(16, e -> {
+            timer = new Timer(12, e -> {
                 long elapsed = System.currentTimeMillis() - startTime;
                 progress = Math.min(1f, elapsed / (float) duration);
                 if (progress >= 1f) {
@@ -6011,14 +6011,11 @@ public class BoardPanel extends JPanel {
             float sizeFactor = 1f + (1f - eased) * 0.5f; // 从 1.5 缩小至 1.0
             int size = (int) (CELL_SIZE * 0.9 * sizeFactor);
 
-            // 阴影始终偏移到棋子右下方，并随棋子尺寸缩放
-            int offsetX = 5;
-            int offsetY = 5;
+            // 右下方月牙形阴影，随着棋子落下逐渐缩小
+            int shadowSize = (int) (CELL_SIZE * 0.8 * (1f - eased));
             Composite old = g2d.getComposite();
             g2d.setColor(new Color(0, 0, 0, 100));
-            g2d.fillOval(centerX + offsetX - size / 2,
-                         centerY + offsetY - size / 2,
-                         size, size);
+            g2d.fillArc(centerX + 10, centerY + 10, shadowSize, shadowSize, 0, 180);
             g2d.setComposite(old);
 
             drawPieceAt(g2d, piece, centerX, centerY, sizeFactor, 1f);
@@ -6083,9 +6080,9 @@ public class BoardPanel extends JPanel {
         }
 
         private void startMove() {
-            int duration = Math.min(320, Math.max(220, ChineseChessConfig.MOVE_ANIMATION_DURATION));
-            timer = new Timer(16, e -> {
-                moveProgress += 16.0 / duration;
+            int duration = Math.min(240, Math.max(160, ChineseChessConfig.MOVE_ANIMATION_DURATION));
+            timer = new Timer(12, e -> {
+                moveProgress += 12.0 / duration;
                 if (moveProgress >= 1.0) {
                     moveProgress = 1.0;
                     timer.stop();
@@ -6101,8 +6098,8 @@ public class BoardPanel extends JPanel {
             impactAnimator.blastAt(endRow, endCol, 2.5, 4, 160);
             SoundManager.play(WOOD, capturedPiece != null ? PIECE_CAPTURE : PIECE_DROP);
             bounceProgress = 0.0;
-            timer = new Timer(16, e -> {
-                bounceProgress += 16.0 / 60.0;
+            timer = new Timer(12, e -> {
+                bounceProgress += 12.0 / 60.0;
                 scale = 1.06 - 0.06 * easeOutCubic(Math.min(1.0, bounceProgress));
                 if (bounceProgress >= 1.0) {
                     timer.stop();
@@ -6129,11 +6126,10 @@ public class BoardPanel extends JPanel {
             int groundY = (int)(startY + (endY - startY) * t);
             int x = (int)((1 - t) * (1 - t) * startX + 2 * (1 - t) * t * ctrlX + t * t * endX);
             int y = (int)((1 - t) * (1 - t) * startY + 2 * (1 - t) * t * ctrlY + t * t * endY);
-            int shadowW = (int)(CELL_SIZE * 0.7 * (1 - 0.3 * hNorm));
-            int shadowH = shadowW / 2;
+            int shadowSize = (int)(CELL_SIZE * 0.7 * (1 - 0.3 * hNorm));
             Composite old = g2d.getComposite();
             g2d.setColor(new Color(0, 0, 0, (int)(80 * (1 - hNorm))));
-            g2d.fillOval(groundX - shadowW/2, groundY - shadowH/2 + CELL_SIZE/4, shadowW, shadowH);
+            g2d.fillArc(groundX + 6, groundY + 6, shadowSize, shadowSize, 0, 180);
             g2d.setComposite(old);
             drawPieceAt(g2d, piece, x, y, scale, 1f);
         }

--- a/chinese-chess/src/main/java/com/example/chinesechess/ui/render/PieceRenderer.java
+++ b/chinese-chess/src/main/java/com/example/chinesechess/ui/render/PieceRenderer.java
@@ -103,8 +103,8 @@ public final class PieceRenderer {
         paintRim(g, cx, cy, rOuter, rimW);
         // 3) 内盘 + 木纹/回退
         paintFace(g, cx, cy, rInner);
-        // 4) 错位深色内圈
-        paintInnerRimOffset(g, cx, cy, rInner, d);
+        // 4) 居中深色内圈
+        paintInnerRim(g, cx, cy, rInner, d);
         // 5) 内盘暗角
         paintVignette(g, cx, cy, rInner);
         // 6) 顶部柔和高光
@@ -206,20 +206,16 @@ public final class PieceRenderer {
         g.setPaint(old);
     }
 
-    // 错位深色内圈：圆心向右下偏移制造厚度错觉
-    private static void paintInnerRimOffset(Graphics2D g, int cx, int cy, int rInner, int d) {
-        int offset = Math.max(2, Math.round(d * 0.04f)); // 错位量
+    // 深色内圈：圆心与棋子圆心一致，确保文字围绕中心
+    private static void paintInnerRim(Graphics2D g, int cx, int cy, int rInner, int d) {
         int ringR = Math.max(1, Math.round(d * 0.02f));  // 圆环粗细
-
-        int ox = cx + offset;
-        int oy = cy + offset;
 
         Stroke bak = g.getStroke();
         Paint old = g.getPaint();
 
         g.setStroke(new BasicStroke(ringR, BasicStroke.CAP_ROUND, BasicStroke.JOIN_ROUND));
         g.setPaint(new Color(0x7A, 0x5A, 0x3B));
-        g.draw(new Ellipse2D.Float(ox - rInner, oy - rInner, rInner * 2f, rInner * 2f));
+        g.draw(new Ellipse2D.Float(cx - rInner, cy - rInner, rInner * 2f, rInner * 2f));
 
         g.setStroke(bak);
         g.setPaint(old);


### PR DESCRIPTION
## Summary
- Center the inner rim of Chinese chess pieces so glyph circles align with piece centers
- Draw crescent-shaped shadows offset to the bottom-right during drop and move animations
- Speed up piece movement with faster timers and shorter durations

## Testing
- `mvn -q -pl chinese-chess -am test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a2ff27c6dc83219645f4a47725a953