### PR TITLE
refactor: share Go stone sound

### DIFF
--- a/game-common/src/main/java/audio/Sfx.java
+++ b/game-common/src/main/java/audio/Sfx.java
@@ -38,18 +38,18 @@ public final class Sfx {
      */
     private static Clip generateClip(boolean tick) {
         try {
-            int samples = (int)(SAMPLE_RATE * (tick ? 0.04 : 0.22));
+            int samples = (int)(SAMPLE_RATE * (tick ? 0.03 : 0.22));
             byte[] data = new byte[samples * 2];
-            double freq = tick ? 5_000 + Math.random() * 2_000
+            double freq = tick ? 7_000 + Math.random() * 3_000
                                : 250 + Math.random() * 200;
             for (int i = 0; i < samples; i++) {
                 double t = i / (double) SAMPLE_RATE;
                 double env = Math.exp(-t * (tick ? 60 : 8));
                 double sample;
                 if (tick) {
-                    // mix sine with a little noise for a crisp click
-                    sample = (Math.sin(2 * Math.PI * freq * t) * 0.7
-                             + (Math.random() * 2 - 1) * 0.3) * env;
+                    // mix sine with minimal noise for a cleaner click
+                    sample = (Math.sin(2 * Math.PI * freq * t) * 0.85
+                             + (Math.random() * 2 - 1) * 0.1) * env;
                 } else {
                     sample = Math.sin(2 * Math.PI * freq * t) * env;
                 }

--- a/gomoku/src/main/java/com/example/gomoku/ui/GomokuBoardPanel.java
+++ b/gomoku/src/main/java/com/example/gomoku/ui/GomokuBoardPanel.java
@@ -4,6 +4,7 @@ import com.example.gomoku.core.GameState;
 import com.example.gomoku.core.GomokuBoard;
 import com.example.gomoku.ChatPanel;
 import audio.SoundManager;
+import audio.Sfx;
 import static audio.SoundManager.Event.*;
 import static audio.SoundManager.SoundProfile.*;
 import com.example.gomoku.ai.GomokuZeroAI;
@@ -62,6 +63,7 @@ public class GomokuBoardPanel extends JPanel {
                 MARGIN * 2 + CELL_SIZE * (GomokuBoard.BOARD_SIZE - 1),
                 MARGIN * 2 + CELL_SIZE * (GomokuBoard.BOARD_SIZE - 1)));
         setBackground(new Color(249, 214, 91)); // 浅黄色背景，模拟木质棋盘
+        Sfx.init();
         
         // 添加鼠标事件监听
         addMouseListener(new MouseAdapter() {
@@ -98,8 +100,8 @@ public class GomokuBoardPanel extends JPanel {
                 // 记录移动历史（用于悔棋）
                 moveHistory.add(new GomokuMoveRecord(row, col, board.isBlackTurn() ? GomokuBoard.WHITE : GomokuBoard.BLACK));
 
-                // 播放落子音效
-                SoundManager.play(STONE, PIECE_DROP);
+                // 播放落子音效（与围棋一致）
+                Sfx.playStoneOnWood(0.7f);
 
                 // 动画与状态更新
                 startDropAnimation(row, col, board.isBlackTurn() ? GomokuBoard.WHITE : GomokuBoard.BLACK);
@@ -174,7 +176,8 @@ public class GomokuBoardPanel extends JPanel {
             moveHistory.add(new GomokuMoveRecord(row, col, board.isBlackTurn() ? GomokuBoard.WHITE : GomokuBoard.BLACK));
 
             // 播放落子音效
-            SoundManager.play(STONE, PIECE_DROP);
+            // 播放落子音效（与围棋一致）
+            Sfx.playStoneOnWood(0.7f);
 
             // 动画与状态更新
             startDropAnimation(row, col, board.isBlackTurn() ? GomokuBoard.WHITE : GomokuBoard.BLACK);


### PR DESCRIPTION
## Summary
- move Go stone sound generator to shared module and refine for crisper click
- use Go-style stone-on-wood sound when placing pieces in Gomoku

## Testing
- `mvn -q -pl game-common,go-game,gomoku -am test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68a30c373d408321a253a3bab6b5a517