### PR TITLE
refactor: share Go stone sound & compact boards

### DIFF
--- a/game-common/src/main/java/audio/Sfx.java
+++ b/game-common/src/main/java/audio/Sfx.java
@@ -38,18 +38,18 @@ public final class Sfx {
      */
     private static Clip generateClip(boolean tick) {
         try {
-            int samples = (int)(SAMPLE_RATE * (tick ? 0.04 : 0.22));
+            int samples = (int)(SAMPLE_RATE * (tick ? 0.03 : 0.22));
             byte[] data = new byte[samples * 2];
-            double freq = tick ? 5_000 + Math.random() * 2_000
+            double freq = tick ? 7_000 + Math.random() * 3_000
                                : 250 + Math.random() * 200;
             for (int i = 0; i < samples; i++) {
                 double t = i / (double) SAMPLE_RATE;
                 double env = Math.exp(-t * (tick ? 60 : 8));
                 double sample;
                 if (tick) {
-                    // mix sine with a little noise for a crisp click
-                    sample = (Math.sin(2 * Math.PI * freq * t) * 0.7
-                             + (Math.random() * 2 - 1) * 0.3) * env;
+                    // mix sine with minimal noise for a cleaner click
+                    sample = (Math.sin(2 * Math.PI * freq * t) * 0.85
+                             + (Math.random() * 2 - 1) * 0.1) * env;
                 } else {
                     sample = Math.sin(2 * Math.PI * freq * t) * env;
                 }

--- a/go-game/src/main/java/com/example/go/GoBoardPanel.java
+++ b/go-game/src/main/java/com/example/go/GoBoardPanel.java
@@ -18,8 +18,8 @@ import java.util.List;
 public class GoBoardPanel extends JPanel {
     private static final int BOARD_SIZE = 19;
     private static final int CELL_SIZE = 30;
-    // 缩小棋盘四周的边距以减少页面空白
-    private static final int MARGIN = 20;
+    // 调整棋盘边距，确保坐标完整且界面紧凑
+    private static final int MARGIN = 25;
     private static final int STONE_RADIUS = 12;
     
     private GoGame game;
@@ -69,10 +69,10 @@ public class GoBoardPanel extends JPanel {
     public GoBoardPanel() {
         this.game = new GoGame();
         Sfx.init();
-        // 调整默认尺寸以适应新的较小边距
+        // 根据棋盘尺寸和边距设置面板大小，避免周围空白
         setPreferredSize(new Dimension(
-            BOARD_SIZE * CELL_SIZE + 2 * MARGIN,
-            BOARD_SIZE * CELL_SIZE + 2 * MARGIN + 40
+            MARGIN * 2 + (BOARD_SIZE - 1) * CELL_SIZE,
+            MARGIN * 2 + (BOARD_SIZE - 1) * CELL_SIZE
         ));
         setBackground(new Color(220, 179, 92)); // 棋盘颜色
         
@@ -517,9 +517,9 @@ public class GoBoardPanel extends JPanel {
     private void drawBoard(Graphics2D g2d) {
         // 绘制棋盘背景
         g2d.setColor(new Color(220, 179, 92));
-        g2d.fillRect(MARGIN - 15, MARGIN - 15, 
-                    BOARD_SIZE * CELL_SIZE + 30, 
-                    BOARD_SIZE * CELL_SIZE + 30);
+        g2d.fillRect(MARGIN - 15, MARGIN - 15,
+                    (BOARD_SIZE - 1) * CELL_SIZE + 30,
+                    (BOARD_SIZE - 1) * CELL_SIZE + 30);
         
         // 绘制棋盘线条
         g2d.setColor(Color.BLACK);
@@ -621,9 +621,9 @@ public class GoBoardPanel extends JPanel {
             // 上方显示坐标
             g2d.drawString(label, x - labelWidth / 2, MARGIN - 10);
             
-            // 下方显示坐标
-            g2d.drawString(label, x - labelWidth / 2, 
-                          MARGIN + BOARD_SIZE * CELL_SIZE + 20);
+            // 下方显示坐标，紧贴棋盘以减少空白
+            g2d.drawString(label, x - labelWidth / 2,
+                          MARGIN + (BOARD_SIZE - 1) * CELL_SIZE + 10);
         }
         
         // 绘制行坐标 (1-19) - 纵坐标，在左侧和右侧都显示
@@ -635,8 +635,8 @@ public class GoBoardPanel extends JPanel {
             // 左侧显示坐标
             g2d.drawString(label, MARGIN - labelWidth - 10, y + 4);
             
-            // 右侧显示坐标
-            g2d.drawString(label, MARGIN + BOARD_SIZE * CELL_SIZE + 10, y + 4);
+            // 右侧显示坐标，紧贴棋盘边缘
+            g2d.drawString(label, MARGIN + (BOARD_SIZE - 1) * CELL_SIZE + 10, y + 4);
         }
     }
     

--- a/gomoku/src/main/java/com/example/gomoku/ui/GomokuBoardPanel.java
+++ b/gomoku/src/main/java/com/example/gomoku/ui/GomokuBoardPanel.java
@@ -4,6 +4,7 @@ import com.example.gomoku.core.GameState;
 import com.example.gomoku.core.GomokuBoard;
 import com.example.gomoku.ChatPanel;
 import audio.SoundManager;
+import audio.Sfx;
 import static audio.SoundManager.Event.*;
 import static audio.SoundManager.SoundProfile.*;
 import com.example.gomoku.ai.GomokuZeroAI;
@@ -40,7 +41,8 @@ public class GomokuBoardPanel extends JPanel {
     private java.util.List<GomokuMoveRecord> moveHistory = new java.util.ArrayList<>();
 
     // 棋盘绘制相关常量
-    private static final int MARGIN = 30; // 棋盘边距
+    // 调整边距使棋盘更紧凑，同时保证坐标完整显示
+    private static final int MARGIN = 25; // 棋盘边距
     private static final int CELL_SIZE = 40; // 格子大小
     private static final int PIECE_SIZE = 34; // 棋子大小
 
@@ -62,6 +64,7 @@ public class GomokuBoardPanel extends JPanel {
                 MARGIN * 2 + CELL_SIZE * (GomokuBoard.BOARD_SIZE - 1),
                 MARGIN * 2 + CELL_SIZE * (GomokuBoard.BOARD_SIZE - 1)));
         setBackground(new Color(249, 214, 91)); // 浅黄色背景，模拟木质棋盘
+        Sfx.init();
         
         // 添加鼠标事件监听
         addMouseListener(new MouseAdapter() {
@@ -98,8 +101,8 @@ public class GomokuBoardPanel extends JPanel {
                 // 记录移动历史（用于悔棋）
                 moveHistory.add(new GomokuMoveRecord(row, col, board.isBlackTurn() ? GomokuBoard.WHITE : GomokuBoard.BLACK));
 
-                // 播放落子音效
-                SoundManager.play(STONE, PIECE_DROP);
+                // 播放落子音效（与围棋一致）
+                Sfx.playStoneOnWood(0.7f);
 
                 // 动画与状态更新
                 startDropAnimation(row, col, board.isBlackTurn() ? GomokuBoard.WHITE : GomokuBoard.BLACK);
@@ -174,7 +177,8 @@ public class GomokuBoardPanel extends JPanel {
             moveHistory.add(new GomokuMoveRecord(row, col, board.isBlackTurn() ? GomokuBoard.WHITE : GomokuBoard.BLACK));
 
             // 播放落子音效
-            SoundManager.play(STONE, PIECE_DROP);
+            // 播放落子音效（与围棋一致）
+            Sfx.playStoneOnWood(0.7f);
 
             // 动画与状态更新
             startDropAnimation(row, col, board.isBlackTurn() ? GomokuBoard.WHITE : GomokuBoard.BLACK);
@@ -371,9 +375,10 @@ public class GomokuBoardPanel extends JPanel {
             int stringWidth = fm.stringWidth(label);
             
             // 上方坐标
-            g2d.drawString(label, x - stringWidth / 2, MARGIN - 8);
-            // 下方坐标
-            g2d.drawString(label, x - stringWidth / 2, MARGIN + (GomokuBoard.BOARD_SIZE - 1) * CELL_SIZE + 20);
+            g2d.drawString(label, x - stringWidth / 2, MARGIN - 10);
+            // 下方坐标（紧贴棋盘边缘，确保不被遮挡）
+            g2d.drawString(label, x - stringWidth / 2,
+                    MARGIN + (GomokuBoard.BOARD_SIZE - 1) * CELL_SIZE + 10);
         }
         
         // 绘制行坐标（1-15）
@@ -384,9 +389,11 @@ public class GomokuBoardPanel extends JPanel {
             int stringHeight = fm.getAscent();
             
             // 左侧坐标
-            g2d.drawString(label, MARGIN - stringWidth - 8, y + stringHeight / 2);
+            g2d.drawString(label, MARGIN - stringWidth - 10, y + stringHeight / 2);
             // 右侧坐标
-            g2d.drawString(label, MARGIN + (GomokuBoard.BOARD_SIZE - 1) * CELL_SIZE + 8, y + stringHeight / 2);
+            g2d.drawString(label,
+                    MARGIN + (GomokuBoard.BOARD_SIZE - 1) * CELL_SIZE + 10,
+                    y + stringHeight / 2);
         }
     }
     


### PR DESCRIPTION
## Summary
- move Go stone sound generator to shared module and refine for crisper click
- use Go-style stone-on-wood sound when placing pieces in Gomoku
- tighten Go and Gomoku board margins so coordinates are fully visible without excess blank space

## Testing
- `mvn -q -pl game-common,go-game,gomoku -am test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68a30c373d408321a253a3bab6b5a517