### PR TITLE
Refactor Gomoku board to reuse Go rendering

### DIFF
--- a/gomoku/pom.xml
+++ b/gomoku/pom.xml
@@ -19,6 +19,12 @@
       <groupId>com.example</groupId>
       <artifactId>game-common</artifactId>
     </dependency>
+
+    <!-- Go module for shared rendering -->
+    <dependency>
+      <groupId>com.example</groupId>
+      <artifactId>go-game</artifactId>
+    </dependency>
     
     <!-- JavaFX -->
     <dependency>


### PR DESCRIPTION
## Summary
- Reuse Go stone renderer and drop animation in Gomoku board
- Align Gomoku grid and coordinates with Go board conventions
- Depend on go-game module for shared rendering utilities

## Testing
- `mvn -q -pl gomoku -am test` *(failed: PluginResolutionException: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a3295880108321ac50d6dcb36745d3