### PR TITLE
Use ring overlay for piece selection

### DIFF
--- a/international-chess/src/main/java/com/example/internationalchess/ui/InternationalBoardPanel.java
+++ b/international-chess/src/main/java/com/example/internationalchess/ui/InternationalBoardPanel.java
@@ -553,8 +553,19 @@ public class InternationalBoardPanel extends JPanel {
     
     private void drawSelection(Graphics2D g2d) {
         if (selectedRow >= 0 && selectedCol >= 0) {
+            int x = selectedCol * CELL_SIZE;
+            int y = selectedRow * CELL_SIZE;
+            int centerX = x + CELL_SIZE / 2;
+            int centerY = y + CELL_SIZE / 2;
+
+            // 根据棋子尺寸计算环半径（略大于棋子底座）
+            int ringRadius = (int) (CELL_SIZE * 0.7 / 2) + 6;
+
+            Stroke oldStroke = g2d.getStroke();
             g2d.setColor(SELECTED_COLOR);
-            g2d.fillRect(selectedCol * CELL_SIZE, selectedRow * CELL_SIZE, CELL_SIZE, CELL_SIZE);
+            g2d.setStroke(new BasicStroke(4f, BasicStroke.CAP_ROUND, BasicStroke.JOIN_ROUND));
+            g2d.drawOval(centerX - ringRadius, centerY - ringRadius, ringRadius * 2, ringRadius * 2);
+            g2d.setStroke(oldStroke);
         }
     }
     


### PR DESCRIPTION
## Summary
- Replace square selection overlay with translucent ring drawn around piece

## Testing
- `mvn -q -pl international-chess -am test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a32956e8048321bc0b5e16ff91ae1f