### PR TITLE
feat: add scalable board rendering

### DIFF
--- a/chinese-chess/src/main/java/com/example/chinesechess/ui/ImpactAnimator.java
+++ b/chinese-chess/src/main/java/com/example/chinesechess/ui/ImpactAnimator.java
@@ -2,6 +2,9 @@ package com.example.chinesechess.ui;
 
 import javax.swing.Timer;
 import java.util.Random;
+import java.awt.Rectangle;
+import java.util.function.Consumer;
+import com.example.chinesechess.config.ChineseChessConfig;
 
 /**
  * 负责在落子冲击时让周围棋子产生抖动效果。
@@ -11,9 +14,10 @@ public class ImpactAnimator {
     private final double[][] offsetY = new double[10][9];
     private Timer timer;
     private final Random random = new Random();
-    private final Runnable repaintCallback;
+    private final Consumer<Rectangle> repaintCallback;
+    private Rectangle repaintArea;
 
-    public ImpactAnimator(Runnable repaintCallback) {
+    public ImpactAnimator(Consumer<Rectangle> repaintCallback) {
         this.repaintCallback = repaintCallback;
     }
 
@@ -37,6 +41,18 @@ public class ImpactAnimator {
                 }
             }
         }
+        int cell = ChineseChessConfig.BOARD_CELL_SIZE;
+        int margin = ChineseChessConfig.BOARD_MARGIN;
+        int rCells = (int) Math.ceil(radiusCells);
+        int minRow = Math.max(0, centerRow - rCells - 1);
+        int maxRow = Math.min(9, centerRow + rCells + 1);
+        int minCol = Math.max(0, centerCol - rCells - 1);
+        int maxCol = Math.min(8, centerCol + rCells + 1);
+        int x = margin + minCol * cell - (int) maxShakePx - 2;
+        int y = margin + minRow * cell - (int) maxShakePx - 2;
+        int w = (maxCol - minCol + 1) * cell + (int) maxShakePx * 2 + 4;
+        int h = (maxRow - minRow + 1) * cell + (int) maxShakePx * 2 + 4;
+        repaintArea = new Rectangle(x, y, w, h);
         if (timer != null) {
             timer.stop();
         }
@@ -49,7 +65,7 @@ public class ImpactAnimator {
                     offsetY[r][c] *= 0.8;
                 }
             }
-            repaintCallback.run();
+            repaintCallback.accept(repaintArea);
             if (--counter[0] <= 0) {
                 timer.stop();
             }

--- a/game-common/src/main/java/com/example/common/ui/overlay/OverlayLayer.java
+++ b/game-common/src/main/java/com/example/common/ui/overlay/OverlayLayer.java
@@ -23,6 +23,7 @@ public class OverlayLayer extends JComponent {
     private final List<Ring> rings = new ArrayList<>();
     private Timer particleTimer;
     private final Random random = new Random();
+    private double viewScale = 1.0;
 
     /** 显示横幅文字 */
     public void showBanner(String text, Style style, int durationMs) {
@@ -119,6 +120,8 @@ public class OverlayLayer extends JComponent {
     protected void paintComponent(Graphics g) {
         super.paintComponent(g);
         Graphics2D g2d = (Graphics2D) g;
+        AffineTransform old = g2d.getTransform();
+        g2d.scale(viewScale, viewScale);
         g2d.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
 
         // 绘制粒子
@@ -169,6 +172,7 @@ public class OverlayLayer extends JComponent {
             g2d.drawOval(r.x - radius, r.y - radius, radius * 2, radius * 2);
             g2d.setComposite(old);
         }
+        g2d.setTransform(old);
     }
 
     private static class Particle {
@@ -184,4 +188,8 @@ public class OverlayLayer extends JComponent {
     }
 
     private Timer impactTimer;
+
+    public void setViewScale(double viewScale) {
+        this.viewScale = viewScale;
+    }
 }


### PR DESCRIPTION
## Summary
- add viewScale-aware drawing to BoardPanel and overlays
- limit repaint to affected regions and scale animation timings
- add region-based ImpactAnimator repaint

## Testing
- `mvn -q -pl chinese-chess -am test` *(fails: PluginResolutionException: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a3295aed648321bbdb4323deace4c6